### PR TITLE
Fix probability returns

### DIFF
--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -226,9 +226,13 @@ def translate_result_type(observable: Observable) -> ResultType:
     Returns:
         ResultType: The Braket result type corresponding to the given observable
     """
-    braket_observable = _translate_observable(observable)
     return_type = observable.return_type
     targets = observable.wires.tolist()
+
+    if return_type is ObservableReturnTypes.Probability:
+        return Probability(targets)
+
+    braket_observable = _translate_observable(observable)
 
     if return_type is ObservableReturnTypes.Expectation:
         return Expectation(braket_observable, targets)
@@ -236,8 +240,6 @@ def translate_result_type(observable: Observable) -> ResultType:
         return Variance(braket_observable, targets)
     elif return_type is ObservableReturnTypes.Sample:
         return Sample(braket_observable, targets)
-    elif return_type is ObservableReturnTypes.Probability:
-        return Probability(targets)
     else:
         raise NotImplementedError(f"Unsupported return type: {return_type}")
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -26,8 +26,6 @@ from pennylane import QubitDevice
 from pennylane import numpy as np
 from pennylane.qnodes import QuantumFunctionError
 from pennylane.tape import QuantumTape
-from pennylane.wires import Wires
-from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin import (
     ISWAP,

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -27,6 +27,7 @@ from pennylane import numpy as np
 from pennylane.qnodes import QuantumFunctionError
 from pennylane.tape import QuantumTape
 from pennylane.wires import Wires
+from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin import (
     ISWAP,
@@ -255,18 +256,14 @@ def test_execute(mock_create):
     mock_create.return_value = TASK
     dev = _device(wires=4, foo="bar")
 
-    circuit = qml.CircuitGraph(
-        [
-            qml.Hadamard(wires=0),
-            qml.CNOT(wires=[0, 1]),
-            qml.probs(wires=[0]),
-            qml.expval(qml.PauliX(1)),
-            qml.var(qml.PauliY(2)),
-            qml.sample(qml.PauliZ(3)),
-        ],
-        {},
-        wires=Wires([0, 1, 2, 3]),
-    )
+    with QuantumTape() as circuit:
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.probs(wires=[0])
+        qml.expval(qml.PauliX(1))
+        qml.var(qml.PauliY(2))
+        qml.sample(qml.PauliZ(3))
+
     results = dev.execute(circuit)
 
     assert np.allclose(
@@ -351,18 +348,14 @@ def test_batch_execute_parallel(mock_run_batch):
     dev = _device(wires=4, foo="bar", parallel=True)
     assert dev.parallel is True
 
-    circuit = qml.CircuitGraph(
-        [
-            qml.Hadamard(wires=0),
-            qml.CNOT(wires=[0, 1]),
-            qml.probs(wires=[0]),
-            qml.expval(qml.PauliX(1)),
-            qml.var(qml.PauliY(2)),
-            qml.sample(qml.PauliZ(3)),
-        ],
-        {},
-        wires=Wires([0, 1, 2, 3]),
-    )
+    with QuantumTape() as circuit:
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.probs(wires=[0])
+        qml.expval(qml.PauliX(1))
+        qml.var(qml.PauliY(2))
+        qml.sample(qml.PauliZ(3))
+
     circuits = [circuit, circuit]
     batch_results = dev.batch_execute(circuits)
     for results in batch_results:
@@ -448,16 +441,12 @@ def test_execute_all_samples(mock_create):
     mock_create.return_value = task
     dev = _device(wires=3)
 
-    circuit = qml.CircuitGraph(
-        [
-            qml.Hadamard(wires=0),
-            qml.CNOT(wires=[0, 1]),
-            qml.sample(qml.Hadamard(0) @ qml.Identity(1)),
-            qml.sample(qml.Hermitian(np.array([[0, 1], [1, 0]]), wires=[2])),
-        ],
-        {},
-        wires=Wires([0, 1, 2]),
-    )
+    with QuantumTape() as circuit:
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.sample(qml.Hadamard(0) @ qml.Identity(1))
+        qml.sample(qml.Hermitian(np.array([[0, 1], [1, 0]]), wires=[2]))
+
     assert dev.execute(circuit).shape == (2, 4)
 
 

--- a/test/unit_tests/test_ops.py
+++ b/test/unit_tests/test_ops.py
@@ -15,7 +15,14 @@ import math
 
 import numpy as np
 import pytest
-from braket.circuits import gates
+from braket.circuits import gates, observables
+from braket.circuits.result_types import Expectation, Probability, Sample, Variance
+import pennylane as qml
+from braket.pennylane_plugin.translation import translate_result_type
+
+from pennylane.tape.measure import MeasurementProcess
+from pennylane.operation import ObservableReturnTypes
+from pennylane.wires import Wires
 
 from braket.pennylane_plugin import (
     ISWAP,
@@ -48,3 +55,38 @@ testdata = [
 def test_matrices(pl_op, braket_gate, params):
     """Tests that the matrices of the custom operations are correct."""
     assert np.allclose(pl_op._matrix(*params), braket_gate(*params).to_matrix())
+
+
+pl_return_types = [
+    ObservableReturnTypes.Expectation,
+    ObservableReturnTypes.Variance,
+    ObservableReturnTypes.Sample,
+]
+
+braket_results = [
+    Expectation(observables.H(), [0]),
+    Variance(observables.H(), [0]),
+    Sample(observables.H(), [0]),
+]
+
+
+@pytest.mark.parametrize("return_type, braket_result", zip(pl_return_types, braket_results))
+def test_translate_result_type_observable(return_type, braket_result):
+    """Tests if a PennyLane return type that involves an observable is successfully converted into a
+    Braket result"""
+    obs = qml.Hadamard(0)
+    obs.return_type = return_type
+    braket_result_calculated = translate_result_type(obs)
+
+    assert braket_result == braket_result_calculated
+
+
+def test_translate_result_type_probs():
+    """Tests if a PennyLane probability return type is successfully converted into a Braket
+    result."""
+    mp = MeasurementProcess(ObservableReturnTypes.Probability, wires=Wires([0]))
+    braket_result_calculated = translate_result_type(mp)
+
+    braket_result = Probability([0])
+
+    assert braket_result == braket_result_calculated

--- a/test/unit_tests/test_ops.py
+++ b/test/unit_tests/test_ops.py
@@ -14,14 +14,12 @@
 import math
 
 import numpy as np
+import pennylane as qml
 import pytest
 from braket.circuits import gates, observables
 from braket.circuits.result_types import Expectation, Probability, Sample, Variance
-import pennylane as qml
-from braket.pennylane_plugin.translation import translate_result_type
-
-from pennylane.tape.measure import MeasurementProcess
 from pennylane.operation import ObservableReturnTypes
+from pennylane.tape.measure import MeasurementProcess
 from pennylane.wires import Wires
 
 from braket.pennylane_plugin import (
@@ -36,6 +34,7 @@ from braket.pennylane_plugin import (
     CPhaseShift01,
     CPhaseShift10,
 )
+from braket.pennylane_plugin.translation import translate_result_type
 
 testdata = [
     (CPhaseShift, gates.CPhaseShift, [math.pi]),

--- a/test/unit_tests/test_ops.py
+++ b/test/unit_tests/test_ops.py
@@ -72,7 +72,7 @@ braket_results = [
 @pytest.mark.parametrize("return_type, braket_result", zip(pl_return_types, braket_results))
 def test_translate_result_type_observable(return_type, braket_result):
     """Tests if a PennyLane return type that involves an observable is successfully converted into a
-    Braket result"""
+    Braket result using translate_result_type"""
     obs = qml.Hadamard(0)
     obs.return_type = return_type
     braket_result_calculated = translate_result_type(obs)
@@ -82,10 +82,29 @@ def test_translate_result_type_observable(return_type, braket_result):
 
 def test_translate_result_type_probs():
     """Tests if a PennyLane probability return type is successfully converted into a Braket
-    result."""
+    result using translate_result_type"""
     mp = MeasurementProcess(ObservableReturnTypes.Probability, wires=Wires([0]))
     braket_result_calculated = translate_result_type(mp)
 
     braket_result = Probability([0])
 
     assert braket_result == braket_result_calculated
+
+
+def test_translate_result_type_unsupported_return():
+    """Tests if a NotImplementedError is raised by translate_result_type for an unknown
+    return_type"""
+    obs = qml.Hadamard(0)
+    obs.return_type = None
+
+    with pytest.raises(NotImplementedError, match="Unsupported return type"):
+        translate_result_type(obs)
+
+
+def test_translate_result_type_unsupported_obs():
+    """Tests if a TypeError is raised by translate_result_type for an unknown observable"""
+    obs = qml.S(wires=0)
+    obs.return_type = None
+
+    with pytest.raises(TypeError, match="Unsupported observable"):
+        translate_result_type(obs)

--- a/test/unit_tests/test_ops.py
+++ b/test/unit_tests/test_ops.py
@@ -14,13 +14,8 @@
 import math
 
 import numpy as np
-import pennylane as qml
 import pytest
-from braket.circuits import gates, observables
-from braket.circuits.result_types import Expectation, Probability, Sample, Variance
-from pennylane.operation import ObservableReturnTypes
-from pennylane.tape.measure import MeasurementProcess
-from pennylane.wires import Wires
+from braket.circuits import gates
 
 from braket.pennylane_plugin import (
     ISWAP,
@@ -34,7 +29,6 @@ from braket.pennylane_plugin import (
     CPhaseShift01,
     CPhaseShift10,
 )
-from braket.pennylane_plugin.translation import translate_result_type
 
 testdata = [
     (CPhaseShift, gates.CPhaseShift, [math.pi]),
@@ -54,57 +48,3 @@ testdata = [
 def test_matrices(pl_op, braket_gate, params):
     """Tests that the matrices of the custom operations are correct."""
     assert np.allclose(pl_op._matrix(*params), braket_gate(*params).to_matrix())
-
-
-pl_return_types = [
-    ObservableReturnTypes.Expectation,
-    ObservableReturnTypes.Variance,
-    ObservableReturnTypes.Sample,
-]
-
-braket_results = [
-    Expectation(observables.H(), [0]),
-    Variance(observables.H(), [0]),
-    Sample(observables.H(), [0]),
-]
-
-
-@pytest.mark.parametrize("return_type, braket_result", zip(pl_return_types, braket_results))
-def test_translate_result_type_observable(return_type, braket_result):
-    """Tests if a PennyLane return type that involves an observable is successfully converted into a
-    Braket result using translate_result_type"""
-    obs = qml.Hadamard(0)
-    obs.return_type = return_type
-    braket_result_calculated = translate_result_type(obs)
-
-    assert braket_result == braket_result_calculated
-
-
-def test_translate_result_type_probs():
-    """Tests if a PennyLane probability return type is successfully converted into a Braket
-    result using translate_result_type"""
-    mp = MeasurementProcess(ObservableReturnTypes.Probability, wires=Wires([0]))
-    braket_result_calculated = translate_result_type(mp)
-
-    braket_result = Probability([0])
-
-    assert braket_result == braket_result_calculated
-
-
-def test_translate_result_type_unsupported_return():
-    """Tests if a NotImplementedError is raised by translate_result_type for an unknown
-    return_type"""
-    obs = qml.Hadamard(0)
-    obs.return_type = None
-
-    with pytest.raises(NotImplementedError, match="Unsupported return type"):
-        translate_result_type(obs)
-
-
-def test_translate_result_type_unsupported_obs():
-    """Tests if a TypeError is raised by translate_result_type for an unknown observable"""
-    obs = qml.S(wires=0)
-    obs.return_type = None
-
-    with pytest.raises(TypeError, match="Unsupported observable"):
-        translate_result_type(obs)

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -1,0 +1,73 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import pennylane as qml
+import pytest
+from braket.circuits import observables
+from braket.circuits.result_types import Expectation, Probability, Sample, Variance
+from pennylane.operation import ObservableReturnTypes
+from pennylane.tape import MeasurementProcess
+from pennylane.wires import Wires
+
+from braket.pennylane_plugin.translation import translate_result_type
+
+pl_return_types = [
+    ObservableReturnTypes.Expectation,
+    ObservableReturnTypes.Variance,
+    ObservableReturnTypes.Sample,
+]
+braket_results = [
+    Expectation(observables.H(), [0]),
+    Variance(observables.H(), [0]),
+    Sample(observables.H(), [0]),
+]
+
+
+@pytest.mark.parametrize("return_type, braket_result", zip(pl_return_types, braket_results))
+def test_translate_result_type_observable(return_type, braket_result):
+    """Tests if a PennyLane return type that involves an observable is successfully converted into a
+    Braket result using translate_result_type"""
+    obs = qml.Hadamard(0)
+    obs.return_type = return_type
+    braket_result_calculated = translate_result_type(obs)
+
+    assert braket_result == braket_result_calculated
+
+
+def test_translate_result_type_probs():
+    """Tests if a PennyLane probability return type is successfully converted into a Braket
+    result using translate_result_type"""
+    mp = MeasurementProcess(ObservableReturnTypes.Probability, wires=Wires([0]))
+    braket_result_calculated = translate_result_type(mp)
+
+    braket_result = Probability([0])
+
+    assert braket_result == braket_result_calculated
+
+
+def test_translate_result_type_unsupported_return():
+    """Tests if a NotImplementedError is raised by translate_result_type for an unknown
+    return_type"""
+    obs = qml.Hadamard(0)
+    obs.return_type = None
+
+    with pytest.raises(NotImplementedError, match="Unsupported return type"):
+        translate_result_type(obs)
+
+
+def test_translate_result_type_unsupported_obs():
+    """Tests if a TypeError is raised by translate_result_type for an unknown observable"""
+    obs = qml.S(wires=0)
+    obs.return_type = None
+
+    with pytest.raises(TypeError, match="Unsupported observable"):
+        translate_result_type(obs)


### PR DESCRIPTION
*Description of changes:* A new version (0.14.0) of PennyLane will shortly be released that makes [tape mode](https://pennylane.readthedocs.io/en/stable/code/qml_tape.html) the default core. This means that the `qml.CircuitGraph` is replaced with a `QuantumTape`, and we also work with a new `QNode`.

A side effect of this change is that returning `qml.probs()` is incompatible with the Braket device when using the new PL core. Indeed, we are now hitting [this](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/0995d01c6de6f042cf64c3c428b0d46fd7e4c68a/src/braket/pennylane_plugin/translation.py#L247) exception.

This is because `qml.probs()` is now more generally a [MeasurementProcess](https://pennylane.readthedocs.io/en/stable/code/api/pennylane.tape.MeasurementProcess.html) - it does not have a corresponding observable. Beforehand, the observable corresponding to `qml.probs()` was `qml.Identity()`, so the logic passed through [this](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/0995d01c6de6f042cf64c3c428b0d46fd7e4c68a/src/braket/pennylane_plugin/translation.py#L271) line.

The solution is simply to move the probability check in [translate_return_type](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/0995d01c6de6f042cf64c3c428b0d46fd7e4c68a/src/braket/pennylane_plugin/translation.py#L220) further up, so that we do not need to look for a corresponding observable.

*Testing done:* The tests now pass with the development branch of PL. We have also changed from `CircuitGraph` to `QuantumTape` in the tests (noticed due to another test failing for `qml.sample`).

Furthermore, we have added the `braket.local.qubit` device to the [PL testing matrix](https://github.com/PennyLaneAI/plugin-test-matrix#testing-matrix). Here, the device is tested against the [standard device test suite](https://github.com/PennyLaneAI/pennylane/tree/master/pennylane/devices/tests).
