### PR TITLE
Fix Braket-PennyLane plugin in preparation for PennyLane v0.15.0 release

### DIFF
--- a/doc/devices/braket_local.rst
+++ b/doc/devices/braket_local.rst
@@ -42,7 +42,7 @@ array([0.97517033, 0.04904283])
 Device options
 ~~~~~~~~~~~~~~
 
-You can set ``shots`` to 0 to get exact results instead of results calculated from samples.
+You can set ``shots`` to ``None`` to get exact results instead of results calculated from samples.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/devices/braket_local.rst
+++ b/doc/devices/braket_local.rst
@@ -42,7 +42,7 @@ array([0.97517033, 0.04904283])
 Device options
 ~~~~~~~~~~~~~~
 
-You can set ``shots`` to ``None`` to get exact results instead of results calculated from samples.
+You can set ``shots`` to ``None`` (default) to get exact results instead of results calculated from samples.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -69,13 +69,12 @@ A timeout of 30 to 60 seconds is recommended for circuits with fewer than 25 qub
 Device options
 ~~~~~~~~~~~~~~
 
-The default value of ``shots`` is ``None``. In this case:
+The default value of the ``shots`` argument is ``Shots.DEFAULT``, resulting in the default number of
+shots specified by the remote device being used. For example, a simulator device may default to
+analytic mode while a QPU must pick a finite number of shots.
 
-- If the device ARN points to a simulator, the device runs in analytic mode (calculations will be
-  exact).
-- If the device ARN points to a QPU, a default nonzero number of shots will be fixed.
-
-Analytic-mode is not available for QPUs and setting ``shots=0`` will raise an error.
+Setting ``shots=0`` or ``shots=None`` will cause the device to run in analytic mode. If the device
+ARN points to a QPU, analytic mode is not available and an error will be raised.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -45,9 +45,8 @@ Enabling the parallel execution of multiple circuits
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Where supported by the backend of the Amazon Braket service, the remote device can be used to execute multiple
-quantum circuits in parallel. To unlock this feature, make sure `tape mode <https://pennylane.readthedocs.io/en/stable/code/qml_tape.html>`_ is enabled in PennyLane, and then instantiate the device using the ``parallel=True`` argument:
+quantum circuits in parallel. To unlock this feature, instantiate the device using the ``parallel=True`` argument:
 
->>> qml.enable_tape()
 >>> remote_device = qml.device('braket.aws.qubit', [... ,] parallel=True)
 
 The details of the parallelization scheme depend on the PennyLane version you use, as well as your AWS account specifications.

--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -66,6 +66,16 @@ You can set a timeout by using the ``poll_timeout_seconds`` argument;
 the device will retry circuits that do not complete within the timeout.
 A timeout of 30 to 60 seconds is recommended for circuits with fewer than 25 qubits.
 
+Device options
+~~~~~~~~~~~~~~
+
+The default value of ``shots`` is ``None``. In this case:
+
+- If the device ARN points to a simulator, the device runs in analytic mode (calculations will be
+  exact).
+- If the device ARN points to a QPU, a default nonzero number of shots will be fixed.
+
+Analytic-mode is not available for QPUs and setting ``shots=0`` will raise an error.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -33,10 +33,16 @@
       </li>
       <li class="nav-item active">
         <a class="nav-link" href="https://pennylane.ai/plugins.html">Plugins</a>
+        <span class="sr-only">(current)</span>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://pennylane.readthedocs.io">Documentation</a>
-          <span class="sr-only">(current)</span>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://pennylane.ai/blog">Blog</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://qhack.ai"><img src="https://pennylane.ai/img/qhack_plain_black.png"></a>
       </li>
     </ul>
     <!-- Links -->

--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -3,6 +3,7 @@
 {# Do this so that bootstrap is included before the main css file #}
 {%- block htmltitle %}
   <link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
 
   <!-- Font Awesome -->

--- a/doc/xanadu_theme/static/xanadu.css_t
+++ b/doc/xanadu_theme/static/xanadu.css_t
@@ -1,7 +1,7 @@
 /* Sphinx themes
 -------------------------------------------------- */
 @font-face {
-  font-family: 'Product Sans';
+  font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 400;
   src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/productsans/v5/HYvgU2fE2nRJvZ5JFAumwegdm0LZdjqr5-oayXSOefg.woff2) format('woff2');
@@ -92,7 +92,7 @@ h1, h2, h3, h4, h5, h6 {
   color: black;
   font-weight: normal;
   padding: 0;
-  font-family: 'Product Sans', 'Roboto', sans-serif!important;
+  font-family: 'Noto Sans', 'Roboto', sans-serif!important;
 }
 
 h1, h2, h3 {
@@ -371,7 +371,7 @@ div.sphinxsidebar p {
   margin: 20px 0px 10px 21px;
   font-weight: normal;
   padding: 0;
-  font-family: 'Product Sans', 'Roboto', sans-serif!important;
+  font-family: 'Noto Sans', 'Roboto', sans-serif!important;
   font-size: 24px;
   color: #515151;
   /*text-align: center;*/
@@ -2012,7 +2012,7 @@ footer.page-footer .footer-copyright {
     margin-left: 20px;
     font-size: initial;
     color: black;
-    font-family: 'Product Sans', 'Roboto', sans-serif !important;
+    font-family: 'Noto Sans', 'Roboto', sans-serif !important;
     margin-bottom: -9px;
     border-bottom: 3px solid;
     border-bottom-color: white;

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.5.0",
-        "pennylane>=0.13.0",
+        "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     ],
     entry_points={
         "pennylane.plugins": [

--- a/src/braket/pennylane_plugin/_version.py
+++ b/src/braket/pennylane_plugin/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.1.0.post1"
+__version__ = "1.1.1.dev0"

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -222,8 +222,9 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         shots (int): Number of circuit evaluations or random samples included,
             to estimate expectation values of observables. If this value is set to ``None``
             and the device ARN points to a simulator, the device runs
-            in analytic mode (calculations will be exact). Trying to use analytic mode
-            with QPUs will fail.
+            in analytic mode (calculations will be exact). If this value is set to ``None`` and the
+            device ARN points to a QPU, a default nonzero number of shots will be used. Analytic
+            mode is not available on QPU and setting ``shots=0`` will raise an error.
             Default: None
         aws_session (Optional[AwsSession]): An AwsSession object created to manage
             interactions with AWS services, to be supplied if extra control

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -225,13 +225,12 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         poll_timeout_seconds (float): Total time in seconds to wait for
             results before timing out.
         poll_interval_seconds (float): The polling interval for results in seconds.
-        shots (int): Number of circuit evaluations or random samples included,
-            to estimate expectation values of observables. If this value is set to ``None``
-            and the device ARN points to a simulator, the device runs
-            in analytic mode (calculations will be exact). If this value is set to ``None`` and the
-            device ARN points to a QPU, a default nonzero number of shots will be used. Analytic
-            mode is not available on QPU and setting ``shots=0`` will raise an error.
-            Default: None
+        shots (int, None or Shots.DEFAULT): Number of circuit evaluations or random samples
+            included, to estimate expectation values of observables. If set to Shots.DEFAULT,
+            uses the default number of shots specified by the remote device. If ``shots`` is set
+            to ``0`` or ``None``, the device runs in analytic mode (calculations will be exact).
+            Analytic mode is not available on QPU and hence an error will be raised.
+            Default: Shots.DEFAULT
         aws_session (Optional[AwsSession]): An AwsSession object created to manage
             interactions with AWS services, to be supplied if extra control
             is desired. Default: None

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -41,10 +41,9 @@ from braket.device_schema import DeviceActionType
 from braket.devices import Device, LocalSimulator
 from braket.simulator import BraketSimulator
 from braket.tasks import GateModelQuantumTaskResult, QuantumTask
-from pennylane import CircuitGraph, QubitDevice
+from pennylane import CircuitGraph, QuantumFunctionError, QubitDevice
 from pennylane import numpy as np
 from pennylane.operation import Expectation, Observable, Operation, Probability, Sample, Variance
-from pennylane import QuantumFunctionError
 
 from braket.pennylane_plugin.translation import (
     supported_operations,

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -44,7 +44,7 @@ from braket.tasks import GateModelQuantumTaskResult, QuantumTask
 from pennylane import CircuitGraph, QubitDevice
 from pennylane import numpy as np
 from pennylane.operation import Expectation, Observable, Operation, Probability, Sample, Variance
-from pennylane.qnodes import QuantumFunctionError
+from pennylane import QuantumFunctionError
 
 from braket.pennylane_plugin.translation import (
     supported_operations,

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -82,7 +82,7 @@ class BraketQubitDevice(QubitDevice):
         shots: int,
         **run_kwargs,
     ):
-        super().__init__(wires, shots=shots)
+        super().__init__(wires, shots=shots or None)
         self._device = device
         self._circuit = None
         self._task = None

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -225,6 +225,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             and the device ARN points to a simulator, the device runs
             in analytic mode (calculations will be exact). Trying to use analytic mode
             with QPUs will fail.
+            Default: None
         aws_session (Optional[AwsSession]): An AwsSession object created to manage
             interactions with AWS services, to be supplied if extra control
             is desired. Default: None
@@ -269,6 +270,9 @@ class BraketAwsQubitDevice(BraketQubitDevice):
 
         if shots is None and device_type == AwsDeviceType.QPU:
             raise ValueError("QPU devices require the number of shots to be specified")
+
+        if not (device_type == AwsDeviceType.SIMULATOR or device_type == AwsDeviceType.QPU):
+            raise ValueError(f"Invalid device type: {device_type}")
 
         super().__init__(wires, device, shots=shots, **run_kwargs)
         self._s3_folder = s3_destination_folder

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -70,7 +70,7 @@ class BraketQubitDevice(QubitDevice):
         **run_kwargs: Variable length keyword arguments for ``braket.devices.Device.run()`.
     """
     name = "Braket PennyLane plugin"
-    pennylane_requires = ">=0.11.0"
+    pennylane_requires = ">=0.15.0"
     version = __version__
     author = "Amazon Web Services"
 

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -34,6 +34,7 @@ Code details
 
 # pylint: disable=invalid-name
 from typing import FrozenSet, Iterable, List, Optional, Sequence, Union
+from enum import Enum, auto
 
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch, AwsSession
 from braket.circuits import Circuit, Instruction
@@ -56,6 +57,11 @@ from ._version import __version__
 RETURN_TYPES = [Expectation, Variance, Sample, Probability]
 
 
+class Shots(Enum):
+    """Used to specify the default number of shots in BraketAwsQubitDevice"""
+    DEFAULT = auto()
+
+
 class BraketQubitDevice(QubitDevice):
     r"""Abstract Amazon Braket qubit device for PennyLane.
 
@@ -64,7 +70,7 @@ class BraketQubitDevice(QubitDevice):
             or iterable that contains unique labels for the subsystems as numbers
             (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
         device (Device): The Amazon Braket device to use with PennyLane.
-        shots (int): Number of circuit evaluations or random samples included,
+        shots (int or None): Number of circuit evaluations or random samples included,
             to estimate expectation values of observables. If this value is set to ``None`` or
             ``0``, the device runs in analytic mode (calculations will be exact).
         **run_kwargs: Variable length keyword arguments for ``braket.devices.Device.run()`.
@@ -79,7 +85,7 @@ class BraketQubitDevice(QubitDevice):
         wires: Union[int, Iterable],
         device: Device,
         *,
-        shots: int,
+        shots: Union[int, None],
         **run_kwargs,
     ):
         super().__init__(wires, shots=shots or None)
@@ -252,7 +258,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         device_arn: str,
         s3_destination_folder: AwsSession.S3DestinationFolder,
         *,
-        shots: Optional[int] = None,
+        shots: Union[int, None, Shots] = Shots.DEFAULT,
         poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
         poll_interval_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
         aws_session: Optional[AwsSession] = None,
@@ -267,16 +273,17 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             raise ValueError(f"Device {device.name} does not support quantum circuits")
 
         device_type = device.type
-        if shots is not None:
-            if shots == 0 and device_type == AwsDeviceType.QPU:
-                raise ValueError("QPU devices do not support 0 shots")
-            num_shots = shots
-        elif device_type == AwsDeviceType.SIMULATOR:
-            num_shots = AwsDevice.DEFAULT_SHOTS_SIMULATOR
-        elif device_type == AwsDeviceType.QPU:
-            num_shots = AwsDevice.DEFAULT_SHOTS_QPU
-        else:
+        if device_type not in (AwsDeviceType.SIMULATOR, AwsDeviceType.QPU):
             raise ValueError(f"Invalid device type: {device_type}")
+
+        if shots == Shots.DEFAULT and device_type == AwsDeviceType.SIMULATOR:
+            num_shots = AwsDevice.DEFAULT_SHOTS_SIMULATOR
+        elif shots == Shots.DEFAULT and device_type == AwsDeviceType.QPU:
+            num_shots = AwsDevice.DEFAULT_SHOTS_QPU
+        elif (shots is None or shots == 0) and device_type == AwsDeviceType.QPU:
+            raise ValueError("QPU devices do not support 0 shots")
+        else:
+            num_shots = shots
 
         super().__init__(wires, device, shots=num_shots, **run_kwargs)
         self._s3_folder = s3_destination_folder

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -266,14 +266,18 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             raise ValueError(f"Device {device.name} does not support quantum circuits")
 
         device_type = device.type
-
-        if shots is None and device_type == AwsDeviceType.QPU:
-            raise ValueError("QPU devices require the number of shots to be specified")
-
-        if not (device_type == AwsDeviceType.SIMULATOR or device_type == AwsDeviceType.QPU):
+        if shots is not None:
+            if shots == 0 and device_type == AwsDeviceType.QPU:
+                raise ValueError("QPU devices do not support 0 shots")
+            num_shots = shots
+        elif device_type == AwsDeviceType.SIMULATOR:
+            num_shots = AwsDevice.DEFAULT_SHOTS_SIMULATOR
+        elif device_type == AwsDeviceType.QPU:
+            num_shots = AwsDevice.DEFAULT_SHOTS_QPU
+        else:
             raise ValueError(f"Invalid device type: {device_type}")
 
-        super().__init__(wires, device, shots=shots, **run_kwargs)
+        super().__init__(wires, device, shots=num_shots, **run_kwargs)
         self._s3_folder = s3_destination_folder
         self._poll_timeout_seconds = poll_timeout_seconds
         self._poll_interval_seconds = poll_interval_seconds

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -32,9 +32,10 @@ Code details
 ~~~~~~~~~~~~
 """
 
+from enum import Enum, auto
+
 # pylint: disable=invalid-name
 from typing import FrozenSet, Iterable, List, Optional, Sequence, Union
-from enum import Enum, auto
 
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch, AwsSession
 from braket.circuits import Circuit, Instruction
@@ -59,6 +60,7 @@ RETURN_TYPES = [Expectation, Variance, Sample, Probability]
 
 class Shots(Enum):
     """Used to specify the default number of shots in BraketAwsQubitDevice"""
+
     DEFAULT = auto()
 
 
@@ -348,7 +350,7 @@ class BraketLocalQubitDevice(BraketQubitDevice):
         backend (Union[str, BraketSimulator]): The name of the simulator backend or
             the actual simulator instance to use for simulation. Defaults to the
             ``default`` simulator backend name.
-        shots (int): Number of circuit evaluations or random samples included,
+        shots (int or None): Number of circuit evaluations or random samples included,
             to estimate expectation values of observables. If this value is set to ``None`` or
             ``0``, then the device runs in analytic mode (calculations will be exact).
             Default: None
@@ -362,7 +364,7 @@ class BraketLocalQubitDevice(BraketQubitDevice):
         wires: Union[int, Iterable],
         backend: Union[str, BraketSimulator] = "default",
         *,
-        shots: Optional[int] = None,
+        shots: Union[int, None] = None,
         **run_kwargs,
     ):
         device = LocalSimulator(backend)

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -65,8 +65,8 @@ class BraketQubitDevice(QubitDevice):
             (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
         device (Device): The Amazon Braket device to use with PennyLane.
         shots (int): Number of circuit evaluations or random samples included,
-            to estimate expectation values of observables. If this value is set to ``None``,
-            the device runs in analytic mode (calculations will be exact).
+            to estimate expectation values of observables. If this value is set to ``None`` or
+            ``0``, the device runs in analytic mode (calculations will be exact).
         **run_kwargs: Variable length keyword arguments for ``braket.devices.Device.run()`.
     """
     name = "Braket PennyLane plugin"
@@ -338,8 +338,8 @@ class BraketLocalQubitDevice(BraketQubitDevice):
             the actual simulator instance to use for simulation. Defaults to the
             ``default`` simulator backend name.
         shots (int): Number of circuit evaluations or random samples included,
-            to estimate expectation values of observables. If this value is set to ``None``,
-            then the device runs in analytic mode (calculations will be exact).
+            to estimate expectation values of observables. If this value is set to ``None`` or
+            ``0``, then the device runs in analytic mode (calculations will be exact).
             Default: None
         **run_kwargs: Variable length keyword arguments for ``braket.devices.Device.run()``.
     """

--- a/test/integ_tests/test_batch.py
+++ b/test/integ_tests/test_batch.py
@@ -125,10 +125,7 @@ def test_batch_execution_of_gradient_torch(device, shots, mocker):
 def test_batch_execution_of_gradient_tf(device, shots, mocker):
     """Test that the output of a parallelized execution of batch circuits to evaluate the
     gradient is correct in comparison to default.qubit when using the tf interface."""
-    try:
-        import tensorflow as tf
-    except ImportError:
-        pytest.skip("This test requires installation of TensorFlow")
+    tf = pytest.importorskip("tensorflow", minversion="2.4")
 
     qubits = 2
     layers = 2

--- a/test/integ_tests/test_batch.py
+++ b/test/integ_tests/test_batch.py
@@ -20,11 +20,10 @@ from pennylane import numpy as np
 from braket.pennylane_plugin import BraketAwsQubitDevice, BraketLocalQubitDevice
 
 
-@pytest.mark.parametrize("shots", [0])
+@pytest.mark.parametrize("shots", [None])
 def test_batch_execution_of_gradient(device, shots, mocker):
     """Test that the output of a parallelized execution of batch circuits to evaluate the
     gradient is correct in comparison to default.qubit."""
-    qml.enable_tape()
     qubits = 2
     layers = 2
 
@@ -64,10 +63,8 @@ def test_batch_execution_of_gradient(device, shots, mocker):
     expected_circuits = qubits * layers * 3 * 2
     assert len(spy2.call_args_list[0][0][1]) == expected_circuits
 
-    qml.disable_tape()
 
-
-@pytest.mark.parametrize("shots", [0])
+@pytest.mark.parametrize("shots", [None])
 def test_batch_execution_of_gradient_torch(device, shots, mocker):
     """Test that the output of a parallelized execution of batch circuits to evaluate the
     gradient is correct in comparison to default.qubit when using the torch interface."""
@@ -76,7 +73,6 @@ def test_batch_execution_of_gradient_torch(device, shots, mocker):
     except ImportError:
         pytest.skip("This test requires installation of torch")
 
-    qml.enable_tape()
     qubits = 2
     layers = 2
 
@@ -124,10 +120,8 @@ def test_batch_execution_of_gradient_torch(device, shots, mocker):
     expected_circuits = qubits * layers * 3 * 2
     assert len(spy2.call_args_list[0][0][1]) == expected_circuits
 
-    qml.disable_tape()
 
-
-@pytest.mark.parametrize("shots", [0])
+@pytest.mark.parametrize("shots", [None])
 def test_batch_execution_of_gradient_tf(device, shots, mocker):
     """Test that the output of a parallelized execution of batch circuits to evaluate the
     gradient is correct in comparison to default.qubit when using the tf interface."""
@@ -136,7 +130,6 @@ def test_batch_execution_of_gradient_tf(device, shots, mocker):
     except ImportError:
         pytest.skip("This test requires installation of TensorFlow")
 
-    qml.enable_tape()
     qubits = 2
     layers = 2
 
@@ -180,5 +173,3 @@ def test_batch_execution_of_gradient_tf(device, shots, mocker):
 
     expected_circuits = qubits * layers * 3 * 2
     assert len(spy2.call_args_list[0][0][1]) == expected_circuits
-
-    qml.disable_tape()

--- a/test/integ_tests/test_integration.py
+++ b/test/integ_tests/test_integration.py
@@ -29,7 +29,7 @@ class TestDeviceIntegration:
         """Test that the device loads correctly"""
         dev = TestDeviceIntegration._device(d, 2, extra_kwargs)
         assert dev.num_wires == 2
-        assert dev.shots == None
+        assert dev.shots is None
         assert dev.short_name == d
 
     def test_args_aws(self):

--- a/test/integ_tests/test_integration.py
+++ b/test/integ_tests/test_integration.py
@@ -29,7 +29,7 @@ class TestDeviceIntegration:
         """Test that the device loads correctly"""
         dev = TestDeviceIntegration._device(d, 2, extra_kwargs)
         assert dev.num_wires == 2
-        assert dev.shots == 1
+        assert dev.shots == None
         assert dev.short_name == d
 
     def test_args_aws(self):
@@ -43,7 +43,7 @@ class TestDeviceIntegration:
             qml.device("braket.local.qubit")
 
     @pytest.mark.parametrize("d", shortnames)
-    @pytest.mark.parametrize("shots", [0, 8192])
+    @pytest.mark.parametrize("shots", [None, 8192])
     def test_one_qubit_circuit(self, shots, d, tol, extra_kwargs):
         """Test that devices provide correct result for a simple circuit"""
         dev = TestDeviceIntegration._device(d, 1, extra_kwargs)

--- a/test/integ_tests/test_var.py
+++ b/test/integ_tests/test_var.py
@@ -19,7 +19,7 @@ import pytest
 np.random.seed(42)
 
 
-@pytest.mark.parametrize("shots", [0, 8192])
+@pytest.mark.parametrize("shots", [None, 8192])
 class TestVar:
     """Tests for the variance"""
 
@@ -62,7 +62,7 @@ class TestVar:
         assert np.allclose(circuit(), expected, **tol)
 
 
-@pytest.mark.parametrize("shots", [0, 8192])
+@pytest.mark.parametrize("shots", [None, 8192])
 class TestTensorVar:
     """Tests for variance of tensor observables"""
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -507,8 +507,15 @@ def test_local_qubit_execute(mock_run, shots):
 
 def test_qpu_default_shots():
     """Tests that QPU devices have the right default value for ``shots``"""
-    with pytest.raises(ValueError, match="QPU devices require the number of shots to be specified"):
-        _aws_device(wires=2, shots=None)
+    dev = _aws_device(wires=2, shots=None)
+    assert dev.shots == AwsDevice.DEFAULT_SHOTS_QPU
+    assert not dev.analytic
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_qpu_0_shots():
+    """Tests that QPUs can not be instantiated with 0 shots"""
+    _aws_device(wires=2, shots=0)
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -41,7 +41,7 @@ from braket.pennylane_plugin import (
     CPhaseShift01,
     CPhaseShift10,
 )
-from braket.pennylane_plugin.braket_device import BraketQubitDevice
+from braket.pennylane_plugin.braket_device import BraketQubitDevice, Shots
 
 SHOTS = 10000
 
@@ -456,7 +456,7 @@ def test_non_jaqcd_device(name_mock):
 
 def test_simulator_default_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
-    dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=None)
+    dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=Shots.DEFAULT)
     assert dev.shots is None
     assert dev.analytic
 
@@ -464,6 +464,13 @@ def test_simulator_default_shots():
 def test_simulator_0_shots():
     """Tests that simulator devices are analytic if ``shots`` is zero"""
     dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=0)
+    assert dev.shots is None
+    assert dev.analytic
+
+
+def test_simulator_none_shots():
+    """Tests that simulator devices are analytic if ``shots`` is None"""
+    dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=None)
     assert dev.shots is None
     assert dev.analytic
 
@@ -482,7 +489,7 @@ def test_local_zero_shots():
     assert dev.analytic
 
 
-def test_local_None_shots():
+def test_local_none_shots():
     """Tests that the simulator devices are analytic if ``shots`` is specified to be `None`."""
     dev = BraketLocalQubitDevice(wires=2, shots=None)
     assert dev.shots is None
@@ -514,7 +521,7 @@ def test_local_qubit_execute(mock_run, shots):
 
 def test_qpu_default_shots():
     """Tests that QPU devices have the right default value for ``shots``"""
-    dev = _aws_device(wires=2, shots=None)
+    dev = _aws_device(wires=2, shots=Shots.DEFAULT)
     assert dev.shots == AwsDevice.DEFAULT_SHOTS_QPU
     assert not dev.analytic
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -468,6 +468,13 @@ def test_local_default_shots():
     assert dev.analytic
 
 
+def test_local_zero_shots():
+    """Test that the local simulator device is analytic if ``shots=0``"""
+    dev = BraketLocalQubitDevice(wires=2, shots=0)
+    assert dev.shots is None
+    assert dev.analytic
+
+
 def test_local_None_shots():
     """Tests that the simulator devices are analytic if ``shots`` is specified to be `None`."""
     dev = BraketLocalQubitDevice(wires=2, shots=None)

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -24,7 +24,7 @@ from braket.device_schema import DeviceActionType
 from braket.tasks import GateModelQuantumTaskResult
 from pennylane import QubitDevice
 from pennylane import numpy as np
-from pennylane.qnodes import QuantumFunctionError
+from pennylane import QuantumFunctionError
 from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin import (

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -456,42 +456,28 @@ def test_non_jaqcd_device(name_mock):
 def test_simulator_default_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
     dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=None)
-    assert dev.shots == 1
-    assert dev.analytic
-
-
-def test_simulator_0_shots():
-    """Tests that simulator devices are analytic if ``shots`` is not supplied"""
-    dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=0)
-    assert dev.shots == 1
+    assert dev.shots == None
     assert dev.analytic
 
 
 def test_local_default_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
     dev = BraketLocalQubitDevice(wires=2)
-    assert dev.shots == 1
+    assert dev.shots == None
     assert dev.analytic
 
 
 def test_local_0_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
-    dev = BraketLocalQubitDevice(wires=2, shots=0)
-    assert dev.shots == 1
+    dev = BraketLocalQubitDevice(wires=2, shots=None)
+    assert dev.shots == None
     assert dev.analytic
 
 
 def test_qpu_default_shots():
     """Tests that QPU devices have the right default value for ``shots``"""
-    dev = _aws_device(wires=2, shots=None)
-    assert dev.shots == AwsDevice.DEFAULT_SHOTS_QPU
-    assert not dev.analytic
-
-
-@pytest.mark.xfail(raises=ValueError)
-def test_qpu_0_shots():
-    """Tests that QPUs can not be instantiated with 0 shots"""
-    _aws_device(wires=2, shots=0)
+    with pytest.raises(ValueError, match="QPU devices require the number of shots to be specified"):
+        _aws_device(wires=2, shots=None)
 
 
 @pytest.mark.xfail(raises=ValueError)
@@ -504,7 +490,7 @@ def test_wires():
     """Test if the apply method supports custom wire labels"""
 
     wires = ["A", 0, "B", -1]
-    dev = _aws_device(wires=wires, device_type=AwsDeviceType.SIMULATOR, shots=0)
+    dev = _aws_device(wires=wires, device_type=AwsDeviceType.SIMULATOR, shots=None)
 
     ops = [qml.RX(0.1, wires="A"), qml.CNOT(wires=[0, "B"]), qml.RY(0.3, wires=-1)]
     target_wires = [[0], [1, 2], [3]]

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -461,6 +461,13 @@ def test_simulator_default_shots():
     assert dev.analytic
 
 
+def test_simulator_0_shots():
+    """Tests that simulator devices are analytic if ``shots`` is zero"""
+    dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=0)
+    assert dev.shots is None
+    assert dev.analytic
+
+
 def test_local_default_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
     dev = BraketLocalQubitDevice(wires=2)

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -22,9 +22,8 @@ from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskB
 from braket.circuits import Circuit, Instruction, Observable, gates, result_types
 from braket.device_schema import DeviceActionType
 from braket.tasks import GateModelQuantumTaskResult
-from pennylane import QubitDevice
+from pennylane import QuantumFunctionError, QubitDevice
 from pennylane import numpy as np
-from pennylane import QuantumFunctionError
 from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin import (
@@ -456,21 +455,21 @@ def test_non_jaqcd_device(name_mock):
 def test_simulator_default_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
     dev = _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, shots=None)
-    assert dev.shots == None
+    assert dev.shots is None
     assert dev.analytic
 
 
 def test_local_default_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
     dev = BraketLocalQubitDevice(wires=2)
-    assert dev.shots == None
+    assert dev.shots is None
     assert dev.analytic
 
 
 def test_local_0_shots():
     """Tests that simulator devices are analytic if ``shots`` is not supplied"""
     dev = BraketLocalQubitDevice(wires=2, shots=None)
-    assert dev.shots == None
+    assert dev.shots is None
     assert dev.analytic
 
 

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -14,8 +14,8 @@ import pennylane as qml
 import pytest
 from braket.circuits import observables
 from braket.circuits.result_types import Expectation, Probability, Sample, Variance
-from pennylane.operation import ObservableReturnTypes
 from pennylane.measure import MeasurementProcess
+from pennylane.operation import ObservableReturnTypes
 from pennylane.wires import Wires
 
 from braket.pennylane_plugin.translation import translate_result_type

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -15,7 +15,7 @@ import pytest
 from braket.circuits import observables
 from braket.circuits.result_types import Expectation, Probability, Sample, Variance
 from pennylane.operation import ObservableReturnTypes
-from pennylane.tape import MeasurementProcess
+from pennylane.measure import MeasurementProcess
 from pennylane.wires import Wires
 
 from braket.pennylane_plugin.translation import translate_result_type


### PR DESCRIPTION
*Issue #, if available:*

Fixes https://github.com/aws/amazon-braket-pennylane-plugin-python/issues/61.

*Context:*

A new version of PennyLane is planned for release next week. This version includes some [changes](https://pennylane.readthedocs.io/en/latest/development/release_notes.html) that impact the Braket-PennyLane device, including:

- The `analytic` keyword argument for devices has been removed. Now, `shots=None` indicates analytic mode. ([PR](https://github.com/PennyLaneAI/pennylane/pull/1079))
- The new Tape-based core is now the default and the old core has been remove ([PR](https://github.com/PennyLaneAI/pennylane/pull/1100)). Consequently, `qml.enable_tape()` is no longer available and should be removed.

The [plugin test matrix](https://github.com/PennyLaneAI/plugin-test-matrix#testing-matrix) shows that this plugin is currently failing when used with the development branch of PennyLane (right-most column). Our objective is to have this column pass. Once the new version of PennyLane has been released, it would then be good to release a new version of this plugin.

*Description of changes:*

This PR fixes the currently broken tests. Most changes involve updating the shots/analytic behaviour and removing `enable_tape()`.

One point for discussion:

For the `BraketAwsQubitDevice`, currently `shots=None` is the default, which is internally converted to a default number of shots set by `AwsDevice.DEFAULT_SHOTS_SIMULATOR` or `AwsDevice.DEFAULT_SHOTS_QPU`. Instead, `shots=0` is used to signify analytic mode (not allowed for QPU devices).

Unfortunately, this is incompatible with the new style in core PennyLane, which uses `shots=None` as the method of selecting analytic mode. The fix in this PR is to keep `shots=None` as the default input (i.e., selecting analytic mode), but _not_ to internally swap that out for a default number set by `AwsDevice.DEFAULT_SHOTS_SIMULATOR` or `AwsDevice.DEFAULT_SHOTS_QPU`. As a consequence, if users try to access a QPU device without specifying the number of shots, they will be met with an error (`"QPU devices require the number of shots to be specified"`).

This is a breaking change for those using hardware devices without explicitly setting `shots`. However, I'd argue that it is better to require users explicitly specify their number of shots (forcing them to think about it), rather than using defaults behind the scenes. On the other hand, we could probably avoid a breaking change if we really want to - e.g., by keeping `shots=None` but swapping out for a default value as before, at a cost of not following core PL.
