### PR TITLE
infra: Crank up coverage to 100%

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.5.0",
-        "pennylane>=0.13.0",
+        "pennylane==0.14.1",
     ],
     entry_points={
         "pennylane.plugins": [

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -72,7 +72,7 @@ class BraketQubitDevice(QubitDevice):
         **run_kwargs: Variable length keyword arguments for ``braket.devices.Device.run()`.
     """
     name = "Braket PennyLane plugin"
-    pennylane_requires = ">=0.11.0"
+    pennylane_requires = "==0.14.1"
     version = __version__
     author = "Amazon Web Services"
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -21,6 +21,7 @@ import pytest
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch
 from braket.circuits import Circuit, Instruction, Observable, gates, result_types
 from braket.device_schema import DeviceActionType
+from braket.devices import LocalSimulator
 from braket.tasks import GateModelQuantumTaskResult
 from pennylane import QubitDevice
 from pennylane import numpy as np
@@ -41,6 +42,7 @@ from braket.pennylane_plugin import (
     CPhaseShift01,
     CPhaseShift10,
 )
+from braket.pennylane_plugin.braket_device import BraketQubitDevice
 
 SHOTS = 10000
 
@@ -481,6 +483,29 @@ def test_local_0_shots():
     assert dev.analytic
 
 
+@patch.object(LocalSimulator, "run")
+@pytest.mark.parametrize("shots", [0, 1000])
+def test_local_qubit_execute(mock_run, shots):
+    """Tests that the local qubit device is run with the correct arguments"""
+    mock_run.return_value = TASK
+    dev = BraketLocalQubitDevice(wires=4, shots=shots, foo="bar")
+
+    with QuantumTape() as circuit:
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.probs(wires=[0])
+        qml.expval(qml.PauliX(1))
+        qml.var(qml.PauliY(2))
+        qml.sample(qml.PauliZ(3))
+
+    dev.execute(circuit)
+    mock_run.assert_called_with(
+        CIRCUIT,
+        shots=shots,
+        foo="bar",
+    )
+
+
 def test_qpu_default_shots():
     """Tests that QPU devices have the right default value for ``shots``"""
     dev = _aws_device(wires=2, shots=None)
@@ -514,6 +539,23 @@ def test_wires():
         wires = op.target
         for w, t in zip(wires, targets):
             assert w == t
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_run_task_unimplemented():
+    """Tests that an error is thrown when _run_task is not implemented"""
+    dev = DummyLocalQubitDevice(wires=2, device=None, shots=1000)
+
+    with QuantumTape() as circuit:
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.probs(wires=[0, 1])
+
+    dev.execute(circuit)
+
+
+class DummyLocalQubitDevice(BraketQubitDevice):
+    short_name = "dummy"
 
 
 def _noop(*args, **kwargs):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds two unit tests to boost coverage to 100%. This ensures that any future PRs that are fully covered but drop the total SLOC don't fail codecov/project due to the drop in total coverage %. Note: PL version has been fixed to 0.14.1 for compatibility.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.