### PR TITLE
fix: Correct parameter-shift rules

### DIFF
--- a/src/braket/pennylane_plugin/ops.py
+++ b/src/braket/pennylane_plugin/ops.py
@@ -372,7 +372,7 @@ class XY(Operation):
           = c_+ \left[ f(XY(\phi + a)) - f(XY(\phi - a)) \right]
           - c_- \left[ f(XY(\phi + b)) - f(XY(\phi - b)) \right]
 
-      where :math:`f` is an expectation value depending on :math:`CR_x(\phi)`, and
+      where :math:`f` is an expectation value depending on :math:`XY(\phi)`, and
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
@@ -438,7 +438,7 @@ class XX(Operation):
           = c_+ \left[ f(XX(\phi + a)) - f(XX(\phi - a)) \right]
           - c_- \left[ f(XX(\phi + b)) - f(XX(\phi - b)) \right]
 
-      where :math:`f` is an expectation value depending on :math:`CR_x(\phi)`, and
+      where :math:`f` is an expectation value depending on :math:`XX(\phi)`, and
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
@@ -501,7 +501,7 @@ class YY(Operation):
           = c_+ \left[ f(YY(\phi + a)) - f(YY(\phi - a)) \right]
           - c_- \left[ f(YY(\phi + b)) - f(YY(\phi - b)) \right]
 
-      where :math:`f` is an expectation value depending on :math:`CR_x(\phi)`, and
+      where :math:`f` is an expectation value depending on :math:`YY(\phi)`, and
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
@@ -564,7 +564,7 @@ class ZZ(Operation):
           = c_+ \left[ f(ZZ(\phi + a)) - f(ZZ(\phi - a)) \right]
           - c_- \left[ f(ZZ(\phi + b)) - f(ZZ(\phi - b)) \right]
 
-      where :math:`f` is an expectation value depending on :math:`CR_x(\phi)`, and
+      where :math:`f` is an expectation value depending on :math:`ZZ(\phi)`, and
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`

--- a/src/braket/pennylane_plugin/ops.py
+++ b/src/braket/pennylane_plugin/ops.py
@@ -373,6 +373,7 @@ class XY(Operation):
           - c_- \left[ f(XY(\phi + b)) - f(XY(\phi - b)) \right]
 
       where :math:`f` is an expectation value depending on :math:`XY(\phi)`, and
+
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
@@ -439,6 +440,7 @@ class XX(Operation):
           - c_- \left[ f(XX(\phi + b)) - f(XX(\phi - b)) \right]
 
       where :math:`f` is an expectation value depending on :math:`XX(\phi)`, and
+
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
@@ -502,6 +504,7 @@ class YY(Operation):
           - c_- \left[ f(YY(\phi + b)) - f(YY(\phi - b)) \right]
 
       where :math:`f` is an expectation value depending on :math:`YY(\phi)`, and
+
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
@@ -565,6 +568,7 @@ class ZZ(Operation):
           - c_- \left[ f(ZZ(\phi + b)) - f(ZZ(\phi - b)) \right]
 
       where :math:`f` is an expectation value depending on :math:`ZZ(\phi)`, and
+
       - :math:`a = \pi/2`
       - :math:`b = 3\pi/2`
       - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`

--- a/src/braket/pennylane_plugin/ops.py
+++ b/src/braket/pennylane_plugin/ops.py
@@ -368,15 +368,15 @@ class XY(Operation):
       (see Appendix F, https://arxiv.org/abs/2104.05695):
 
       .. math::
-          \frac{d}{d\phi}f(XY(\phi))
+          \frac{d}{d \phi} f(XY(\phi))
           = c_+ \left[ f(XY(\phi + a)) - f(XY(\phi - a)) \right]
           - c_- \left[ f(XY(\phi + b)) - f(XY(\phi - b)) \right]
 
       where :math:`f` is an expectation value depending on :math:`XY(\phi)`, and
 
-      - :math:`a = \pi/2`
-      - :math:`b = 3\pi/2`
-      - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
+      - :math:`a = \pi / 2`
+      - :math:`b = 3 \pi / 2`
+      - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4 \sqrt{2}}`
 
     Args:
         phi (float): the phase angle
@@ -431,19 +431,11 @@ class XX(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
-    * Gradient recipe: The XX operator satisfies a four-term parameter-shift rule
-      (see Appendix F, https://arxiv.org/abs/2104.05695):
+    * Gradient recipe:
 
-      .. math::
-          \frac{d}{d\phi}f(XX(\phi))
-          = c_+ \left[ f(XX(\phi + a)) - f(XX(\phi - a)) \right]
-          - c_- \left[ f(XX(\phi + b)) - f(XX(\phi - b)) \right]
-
-      where :math:`f` is an expectation value depending on :math:`XX(\phi)`, and
-
-      - :math:`a = \pi/2`
-      - :math:`b = 3\pi/2`
-      - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
+    .. math::
+        \frac{d}{d \phi} \mathtt{XX}(\phi)
+        = \frac{1}{2} \left[ \mathtt{XX}(\phi + \pi / 2) + \mathtt{XX}(\phi - \pi / 2) \right]
 
     Args:
         phi (float): the phase angle
@@ -453,7 +445,6 @@ class XX(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    grad_recipe = four_term_grad_recipe
 
     @staticmethod
     def decomposition(phi, wires):
@@ -495,19 +486,11 @@ class YY(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
-    * Gradient recipe: The YY operator satisfies a four-term parameter-shift rule
-      (see Appendix F, https://arxiv.org/abs/2104.05695):
+    * Gradient recipe:
 
-      .. math::
-          \frac{d}{d\phi}f(YY(\phi))
-          = c_+ \left[ f(YY(\phi + a)) - f(YY(\phi - a)) \right]
-          - c_- \left[ f(YY(\phi + b)) - f(YY(\phi - b)) \right]
-
-      where :math:`f` is an expectation value depending on :math:`YY(\phi)`, and
-
-      - :math:`a = \pi/2`
-      - :math:`b = 3\pi/2`
-      - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
+    .. math::
+        \frac{d}{d \phi} \mathtt{YY}(\phi)
+        = \frac{1}{2} \left[ \mathtt{YY}(\phi + \pi / 2) + \mathtt{YY}(\phi - \pi / 2) \right]
 
     Args:
         phi (float): the phase angle
@@ -517,7 +500,6 @@ class YY(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    grad_recipe = four_term_grad_recipe
 
     @staticmethod
     def decomposition(phi, wires):
@@ -559,19 +541,11 @@ class ZZ(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
-    * Gradient recipe: The ZZ operator satisfies a four-term parameter-shift rule
-      (see Appendix F, https://arxiv.org/abs/2104.05695):
+    * Gradient recipe:
 
-      .. math::
-          \frac{d}{d\phi}f(ZZ(\phi))
-          = c_+ \left[ f(ZZ(\phi + a)) - f(ZZ(\phi - a)) \right]
-          - c_- \left[ f(ZZ(\phi + b)) - f(ZZ(\phi - b)) \right]
-
-      where :math:`f` is an expectation value depending on :math:`ZZ(\phi)`, and
-
-      - :math:`a = \pi/2`
-      - :math:`b = 3\pi/2`
-      - :math:`c_{\pm} = (\sqrt{2} \pm 1)/{4\sqrt{2}}`
+    .. math::
+        \frac{d}{d \phi} \mathtt{ZZ}(\phi)
+        = \frac{1}{2} \left[ \mathtt{ZZ}(\phi + \pi / 2) + \mathtt{ZZ}(\phi - \pi / 2) \right]
 
     Args:
         phi (float): the phase angle
@@ -581,7 +555,6 @@ class ZZ(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    grad_recipe = four_term_grad_recipe
 
     @staticmethod
     def decomposition(phi, wires):

--- a/test/unit_tests/test_ops.py
+++ b/test/unit_tests/test_ops.py
@@ -15,10 +15,11 @@ import itertools
 import math
 from unittest.mock import patch
 
-from autograd import deriv, numpy as anp
 import numpy as np
 import pennylane as qml
 import pytest
+from autograd import deriv
+from autograd import numpy as anp
 from braket.circuits import gates
 
 from braket.pennylane_plugin import (
@@ -49,7 +50,7 @@ gates_2q_parametrized = [
 ]
 
 observables_1q = [
-    obs._matrix() for obs in[qml.Hadamard, qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ]
+    obs._matrix() for obs in [qml.Hadamard, qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ]
 ]
 observables_2q = [
     np.kron(obs1, obs2) for obs1, obs2 in itertools.product(observables_1q, observables_1q)
@@ -88,6 +89,7 @@ def test_param_shift_2q(pl_op, braket_gate, angle, observable):
     def conj_obs_gate(angle):
         mat = pl_op._matrix(angle)
         return anp.matmul(anp.matmul(anp.transpose(anp.conj(mat)), observable), mat)
+
     direct_calculation = deriv(conj_obs_gate)(angle)
 
     assert np.allclose(from_shifts, direct_calculation)


### PR DESCRIPTION
Corrected the XY gate to use the four-term rule introduced in https://arxiv.org/abs/2104.05695. Added unit tests to ensure correctness of parameter shift rules.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.