### PR TITLE
feature: Support for Hamiltonians

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk",
-        "pennylane>=0.17.0",
+        "pennylane>=0.18.0",
     ],
     entry_points={
         "pennylane.plugins": [

--- a/test/integ_tests/test_expval.py
+++ b/test/integ_tests/test_expval.py
@@ -164,6 +164,22 @@ class TestExpval:
         )
         assert np.allclose(circuit(), expected, **tol)
 
+    def test_hamiltonian(self, device, shots, tol):
+        """Test that Hamiltonian expectation value is correct"""
+        dev = device(2)
+
+        theta = 0.432
+        phi = 0.123
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(theta, wires=[0])
+            qml.RX(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.Hamiltonian((2, 3), (qml.PauliZ(0), qml.PauliY(1))))
+
+        assert np.allclose(circuit(), 2 * np.cos(theta) - 3 * np.cos(theta) * np.sin(phi), **tol)
+
     def test_nondiff_param(self, device):
         """Test that the device can be successfully executed with the Autograd
         interface when some of the arguments are tensors with requires_grad=False"""

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -250,6 +250,30 @@ def test_pl_to_braket_circuit():
     assert braket_circuit_true == braket_circuit
 
 
+def test_pl_to_braket_circuit_hamiltonian():
+    """Tests that a PennyLane circuit is correctly converted into a Braket circuit"""
+    dev = _aws_device(wires=2, foo="bar")
+
+    with QuantumTape() as tape:
+        qml.RX(0.2, wires=0)
+        qml.RX(0.3, wires=1)
+        qml.CNOT(wires=[0, 1])
+        qml.expval(qml.Hamiltonian((2, 3), (qml.PauliX(wires=0), qml.PauliY(wires=1))))
+
+    braket_circuit_true = (
+        Circuit()
+        .rx(0, 0.2)
+        .rx(1, 0.3)
+        .cnot(0, 1)
+        .expectation(Observable.X(), [0])
+        .expectation(Observable.Y(), [1])
+    )
+
+    braket_circuit = dev._pl_to_braket_circuit(tape)
+
+    assert braket_circuit_true == braket_circuit
+
+
 def test_bad_statistics():
     """Test if a QuantumFunctionError is raised for an invalid return type"""
     dev = _aws_device(wires=1, foo="bar")


### PR DESCRIPTION
Adds support for direct evaluation of Hamiltonian expectation values
when `shots=None`; instead of running a circuit for each term or QWC
group, the expectation value can be calculated with one circuit.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.