### PR TITLE
change: make s3_bucket optional

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -313,7 +313,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         self,
         wires: Union[int, Iterable],
         device_arn: str,
-        s3_destination_folder: AwsSession.S3DestinationFolder,
+        s3_destination_folder: AwsSession.S3DestinationFolder = None,
         *,
         shots: Union[int, None, Shots] = Shots.DEFAULT,
         poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,

--- a/test/integ_tests/test_integration.py
+++ b/test/integ_tests/test_integration.py
@@ -35,7 +35,7 @@ class TestDeviceIntegration:
 
     def test_args_aws(self):
         """Test that BraketAwsDevice requires correct arguments"""
-        with pytest.raises(TypeError, match="missing 3 required positional arguments"):
+        with pytest.raises(TypeError, match="missing 2 required positional arguments"):
             qml.device("braket.aws.qubit")
 
     def test_args_local(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- s3_destination folder should not be a mandatory parameter for pennylane notebooks, default bucket is used/created if s3 details are not provided by the customer.

*Testing done:*
tox, tested submitting task without bucket details provided.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.