### PR TITLE
fix: fixing change of location of ObservableReturnTypes

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx-automodapi
-pennylane==0.21.0
+pennylane==0.23.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx-automodapi
-pennylane==0.23.0
+pennylane

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx-automodapi
-pennylane
+pennylane>=0.23.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk",
-        "pennylane>=0.22.0",
+        "pennylane>=0.23.0",
     ],
     entry_points={
         "pennylane.plugins": [

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -27,7 +27,8 @@ from braket.circuits.result_types import (
 from braket.devices import Device
 from braket.tasks import GateModelQuantumTaskResult
 from pennylane import numpy as np
-from pennylane.operation import Observable, ObservableReturnTypes, Operation
+from pennylane.measurements import ObservableReturnTypes
+from pennylane.operation import Observable, Operation
 
 from braket.pennylane_plugin.ops import ECR, PSWAP, XY, CPhaseShift00, CPhaseShift01, CPhaseShift10
 

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -26,8 +26,7 @@ from braket.circuits.result_types import (
     Variance,
 )
 from braket.tasks import GateModelQuantumTaskResult
-from pennylane.measurements import MeasurementProcess
-from pennylane.operation import ObservableReturnTypes
+from pennylane.measurements import MeasurementProcess, ObservableReturnTypes
 from pennylane.wires import Wires
 
 from braket.pennylane_plugin import ECR, PSWAP, XY, CPhaseShift00, CPhaseShift01, CPhaseShift10


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-braket-pennylane-plugin-python/issues/96

*Description of changes:*
Changed the import of ObservableReturnTypes to the measurements module.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.