### PR TITLE
Fix tests for grad recipe changes in PL v0.24

### DIFF
--- a/src/braket/pennylane_plugin/ops.py
+++ b/src/braket/pennylane_plugin/ops.py
@@ -410,15 +410,10 @@ class XY(Operation):
     grad_method = "A"
     parameter_frequencies = [(0.5, 1.0)]
 
-    # TODO: Modify generator function for this class, add scalar multiplication for hamiltonians
-    #  back when this issue is fixed: https://github.com/PennyLaneAI/pennylane/issues/2361
     def generator(self):
-        return qml.Hamiltonian(
-            [0.25, 0.25],
-            [
-                qml.PauliX(wires=self.wires[0]) @ qml.PauliX(wires=self.wires[1]),
-                qml.PauliY(wires=self.wires[0]) @ qml.PauliY(wires=self.wires[1]),
-            ],
+        return 0.25 * (
+            qml.PauliX(wires=self.wires[0]) @ qml.PauliX(wires=self.wires[1])
+            + qml.PauliY(wires=self.wires[0]) @ qml.PauliY(wires=self.wires[1])
         )
 
     def __init__(self, phi, wires, do_queue=True, id=None):

--- a/test/unit_tests/test_ops.py
+++ b/test/unit_tests/test_ops.py
@@ -85,6 +85,9 @@ def test_param_shift_2q(pl_op, braket_gate, angle, observable):
     op = pl_op(angle, wires=[0, 1])
     if op.grad_recipe[0]:
         shifts = op.grad_recipe[0]
+    elif qml.version() >= "0.24.0":
+        orig_shifts = qml.gradients.generate_shift_rule(op.parameter_frequencies[0])
+        shifts = [[c, 1, s] for c, s in orig_shifts]
     else:
         cs, ss = qml.gradients.generate_shift_rule(op.parameter_frequencies[0])
         shifts = [[c, 1, s] for c, s in zip(cs, ss)]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PennyLane gradient recipes were changed in https://github.com/PennyLaneAI/pennylane/pull/2452 for version 0.24, which breaks the unit tests. Hopefully this should fix the test.

*Testing done:* Local testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.