### PR TITLE
fix: Only support adjoint gradient if shots=0

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -504,7 +504,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         capabilities = BraketQubitDevice.capabilities().copy()
         # if this method is called as a class method, don't add provides_jacobian since
         # we don't know if the device is sv1
-        if self and "AdjointGradient" in self._braket_result_types:
+        if self and "AdjointGradient" in self._braket_result_types and not self.shots:
             capabilities.update(provides_jacobian=True)
         return capabilities
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1246,9 +1246,26 @@ def test_capabilities_class_and_instance_method():
         "supports_inverse_operations": True,
     }
     assert class_caps == expected_caps
-    # the instance should have provides_jacobian because AdjointGradient is in the
-    # supported result types
-    expected_caps["provides_jacobian"] = True
+    # the instance should not have provides_jacobian, even though AdjointGradient is in the
+    # supported result types, because shots != 0
+    assert instance_caps == expected_caps
+
+
+def test_capabilities_adjoint_shots_0():
+    instance_caps = _aws_device(
+        wires=2, device_type=AwsDeviceType.SIMULATOR, shots=0
+    ).capabilities()
+    expected_caps = {
+        "model": "qubit",
+        "supports_broadcasting": False,
+        "supports_finite_shots": True,
+        "supports_tensor_observables": True,
+        "returns_probs": True,
+        "supports_inverse_operations": True,
+        # the instance should have provides_jacobian because AdjointGradient is in the
+        # supported result types and shots == 0
+        "provides_jacobian": True,
+    }
     assert instance_caps == expected_caps
 
 


### PR DESCRIPTION
Right now, `BraketAwsQubitDevice` will _always_ calculate gradients with the adjoint method if the underlying device supports it, even when shots>0; this doesn't work because the adjoint gradient only makes sense for shots=0. This commit tightens the adjoint gradient support check to include shots=0.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.