### PR TITLE
cap pennylane version at v0.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.35.0",
-        "pennylane>=0.25.1",
+        "pennylane>=0.25.1,<=0.27.0",
     ],
     entry_points={
         "pennylane.plugins": [

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -346,16 +346,12 @@ CIRCUIT_4.trainable_params = []
                     },
                 },
             ],
-            np.tensor(
-                [
-                    [
-                        np.tensor([0.0], requires_grad=True),
-                        np.tensor([-0.194399, 0.9316158], requires_grad=True),
-                    ]
-                ],
-                dtype=object,
-                requires_grad=True,
-            ),
+            [
+                (
+                    np.tensor([0.0], requires_grad=True),
+                    np.tensor([-0.194399, 0.9316158], requires_grad=True),
+                )
+            ],
         ),
         (
             CIRCUIT_2,
@@ -385,16 +381,12 @@ CIRCUIT_4.trainable_params = []
                     },
                 },
             ],
-            np.tensor(
-                [
-                    [
-                        np.tensor([0.0], requires_grad=True),
-                        np.tensor([-0.01894799, 0.9316158], requires_grad=True),
-                    ]
-                ],
-                dtype=object,
-                requires_grad=True,
-            ),
+            [
+                (
+                    np.tensor([0.0], requires_grad=True),
+                    np.tensor([-0.01894799, 0.9316158], requires_grad=True),
+                )
+            ],
         ),
         (
             CIRCUIT_3,
@@ -426,16 +418,12 @@ CIRCUIT_4.trainable_params = []
                     },
                 },
             ],
-            np.tensor(
-                [
-                    [
-                        np.tensor([0.0], requires_grad=True),
-                        np.tensor([-0.01894799, 0.9316158], requires_grad=True),
-                    ]
-                ],
-                dtype=object,
-                requires_grad=True,
-            ),
+            [
+                (
+                    np.tensor([0.0], requires_grad=True),
+                    np.tensor([-0.01894799, 0.9316158], requires_grad=True),
+                )
+            ],
         ),
     ],
 )


### PR DESCRIPTION
*Description of changes:*
Pennylane released v0.28 on Monday. This new version causes some unit tests to fail. Capping the Pennylane version at v0.27.0 for now.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.