### PR TITLE
fix: `shots=0` measurements with trainable params

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -46,12 +46,13 @@ from braket.device_schema import DeviceActionType
 from braket.devices import Device, LocalSimulator
 from braket.simulator import BraketSimulator
 from braket.tasks import GateModelQuantumTaskResult, QuantumTask
-from pennylane import CircuitGraph, QuantumFunctionError, QubitDevice
+from pennylane import QuantumFunctionError, QubitDevice
 from pennylane import numpy as np
 from pennylane.gradients import param_shift
 from pennylane.measurements import Expectation, Probability, Sample, State, Variance
 from pennylane.operation import Observable, Operation
 from pennylane.ops.qubit.hamiltonian import Hamiltonian
+from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin.translation import (
     get_adjoint_gradient_result_type,
@@ -150,7 +151,7 @@ class BraketQubitDevice(QubitDevice):
         """QuantumTask: The task corresponding to the last run circuit."""
         return self._task
 
-    def _pl_to_braket_circuit(self, circuit: CircuitGraph, compute_gradient=False, **run_kwargs):
+    def _pl_to_braket_circuit(self, circuit: QuantumTape, compute_gradient=False, **run_kwargs):
         """Converts a PennyLane circuit to a Braket circuit"""
         braket_circuit = self.apply(
             circuit.operations,
@@ -290,7 +291,7 @@ class BraketQubitDevice(QubitDevice):
         else:
             return {"braket_failed_task_id": task.id}
 
-    def execute(self, circuit: CircuitGraph, compute_gradient=False, **run_kwargs) -> np.ndarray:
+    def execute(self, circuit: QuantumTape, compute_gradient=False, **run_kwargs) -> np.ndarray:
         self.check_validity(circuit.operations, circuit.observables)
         self._circuit = self._pl_to_braket_circuit(
             circuit, compute_gradient=compute_gradient, **run_kwargs

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -554,7 +554,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         res = []
         jacs = []
         for circuit in circuits:
-            observables: List[Observable] = circuit.observables
+            observables = circuit.observables
             if not circuit.trainable_params:
                 new_res = self.execute(circuit, compute_gradient=False)
                 # don't bother computing a gradient when there aren't any trainable parameters.
@@ -565,7 +565,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
                     self.execute(c, compute_gradient=False) for c in gradient_circuits
                 ]
                 new_jac = post_processing_fn(grad_circuit_results)
-                new_res = self.execute(circuit, compute_grad=False)
+                new_res = self.execute(circuit, compute_gradient=False)
             else:
                 results = self.execute(circuit, compute_gradient=True)
                 new_res, new_jac = results[0]


### PR DESCRIPTION
Fixes #129 by establishing a code path for running circuits with trainable parameters and either variance measurements or multiple observables when shots=0.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.