### PR TITLE
Only include trainable parameters in `inputs`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,6 @@ Amazon Braket PennyLane Plugin
 .. image:: https://img.shields.io/readthedocs/amazon-braket-pennylane-plugin-python.svg?logo=read-the-docs
     :alt: Documentation Status
     :target: https://amazon-braket-pennylane-plugin-python.readthedocs.io/en/latest/?badge=latest
-.. image:: https://img.shields.io/badge/code_style-black-000000.svg
-    :alt: Code Style: Black
-    :target: https://github.com/psf/black
 
 The Amazon Braket PennyLane plugin offers two Amazon Braket quantum devices to work with PennyLane:
 

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -37,7 +37,7 @@ import numbers
 
 # pylint: disable=invalid-name
 from enum import Enum, auto
-from typing import FrozenSet, Iterable, List, Optional, Sequence, Union
+from typing import Dict, FrozenSet, Iterable, List, Optional, Sequence, Union
 
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch, AwsSession
 from braket.circuits import Circuit, Instruction
@@ -151,12 +151,19 @@ class BraketQubitDevice(QubitDevice):
         """QuantumTask: The task corresponding to the last run circuit."""
         return self._task
 
-    def _pl_to_braket_circuit(self, circuit: QuantumTape, compute_gradient=False, **run_kwargs):
+    def _pl_to_braket_circuit(
+        self,
+        circuit: QuantumTape,
+        compute_gradient: bool = False,
+        trainable_indices: FrozenSet[int] = None,
+        **run_kwargs,
+    ):
         """Converts a PennyLane circuit to a Braket circuit"""
         braket_circuit = self.apply(
             circuit.operations,
             rotations=None,  # Diagonalizing gates are applied in Braket SDK
-            use_unique_params=compute_gradient,
+            use_unique_params=False,
+            trainable_indices=trainable_indices,
             **run_kwargs,
         )
         if compute_gradient:
@@ -190,17 +197,6 @@ class BraketQubitDevice(QubitDevice):
             targets = [self.map_wires(op.wires) for op in pl_observable.ops]
         else:
             targets = self.map_wires(pl_observable.wires).tolist()
-        param_index = 0
-        params_not_to_diff = {}
-        for operation in circuit.operations:
-            for p in operation.parameters:
-                if param_index not in circuit.trainable_params:
-                    params_not_to_diff[f"p_{param_index}"] = p
-                param_index += 1
-
-        # bind all the non-trainable parameters since they don't need to be parameters in the
-        # Amazon Braket service.
-        braket_circuit = braket_circuit(**params_not_to_diff)
 
         braket_circuit.add_result_type(
             get_adjoint_gradient_result_type(
@@ -293,20 +289,18 @@ class BraketQubitDevice(QubitDevice):
 
     def execute(self, circuit: QuantumTape, compute_gradient=False, **run_kwargs) -> np.ndarray:
         self.check_validity(circuit.operations, circuit.observables)
+        trainable = BraketQubitDevice._get_trainable_parameters(circuit) if compute_gradient else {}
         self._circuit = self._pl_to_braket_circuit(
-            circuit, compute_gradient=compute_gradient, **run_kwargs
+            circuit,
+            compute_gradient=compute_gradient,
+            trainable_indices=frozenset(trainable.keys()),
+            **run_kwargs,
         )
         if self._noise_model:
             self._circuit = self._noise_model.apply(self._circuit)
-        param_index = 0
-        param_dict = {}
-        for operation in circuit.operations:
-            for p in operation.parameters:
-                if isinstance(p, numbers.Number):
-                    param_name = f"p_{param_index}"
-                    param_dict[param_name] = p
-                    param_index += 1
-        self._task = self._run_task(self._circuit, inputs=param_dict)
+        self._task = self._run_task(
+            self._circuit, inputs={f"p_{k}": v for k, v in trainable.items()}
+        )
         braket_result = self._task.result()
 
         if self.tracker.active:
@@ -319,20 +313,30 @@ class BraketQubitDevice(QubitDevice):
         self,
         operations: Sequence[Operation],
         rotations: Sequence[Operation] = None,
-        use_unique_params=False,
+        use_unique_params: bool = False,
+        *,
+        trainable_indices: Optional[FrozenSet[int]] = None,
         **run_kwargs,
     ) -> Circuit:
         """Instantiate Braket Circuit object."""
         rotations = rotations or []
         circuit = Circuit()
+        trainable_indices = trainable_indices or frozenset()
 
         # Add operations to Braket Circuit object
         param_index = 0
         for operation in operations + rotations:
-            param_names = [f"p_{param_index+i}" for i, p in enumerate(operation.parameters)]
-            param_index += len(operation.parameters)
+            param_names = []
+            for _ in operation.parameters:
+                if param_index in trainable_indices or use_unique_params:
+                    param_names.append(f"p_{param_index}")
+                else:
+                    param_names.append(None)
+                param_index += 1
             gate = translate_operation(
-                operation, use_unique_params=use_unique_params, param_names=param_names
+                operation,
+                use_unique_params=bool(trainable_indices) or use_unique_params,
+                param_names=param_names,
             )
             dev_wires = self.map_wires(operation.wires).tolist()
             ins = Instruction(gate, dev_wires)
@@ -375,6 +379,21 @@ class BraketQubitDevice(QubitDevice):
     def _get_statistic(self, braket_result, observable):
         dev_wires = self.map_wires(observable.wires).tolist()
         return translate_result(braket_result, observable, dev_wires, self._braket_result_types)
+
+    @staticmethod
+    def _get_trainable_parameters(tape: QuantumTape) -> Dict[int, numbers.Number]:
+        trainable_indices = sorted(tape.trainable_params)
+        params = tape.get_parameters()
+        trainable = {}
+        for i in range(len(trainable_indices)):
+            param = params[i]
+            if isinstance(param, numbers.Number):
+                trainable[trainable_indices[i]] = param
+            elif isinstance(param, np.tensor):
+                param_np = param.numpy()
+                if isinstance(param_np, numbers.Number):
+                    trainable[trainable_indices[i]] = param_np
+        return trainable
 
 
 class BraketAwsQubitDevice(BraketQubitDevice):
@@ -607,5 +626,8 @@ class BraketLocalQubitDevice(BraketQubitDevice):
 
     def _run_task(self, circuit, inputs=None):
         return self._device.run(
-            circuit, shots=0 if self.analytic else self.shots, **self._run_kwargs
+            circuit,
+            shots=0 if self.analytic else self.shots,
+            inputs=inputs or {},
+            **self._run_kwargs,
         )

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import numbers
 from functools import reduce, singledispatch
 from typing import Any, FrozenSet, List, Optional, Tuple, Union
 
@@ -125,25 +124,27 @@ def translate_operation(
         use_unique_params (bool): If true, numeric parameters in the resulting operation will be
         replaced with FreeParameter objects (with names corresponding to param_names). Non-numeric
         parameters will be skipped.
-        param_names (Optional[List[str]]): A list of parameter names
-            to be supplied to the new operation.
+        param_names (Optional[List[str]]): A list of parameter names to be supplied
+            to the new operation. The length of the list must match the number of
+            the operator's parameters; if no named parameter is needed for the corresponding
+            operation parameter, then the list entry should be `None`.
 
     Returns:
         Gate: The Braket gate corresponding to the given operation
     """
     if use_unique_params:
-        param_names = param_names or []
         parameters = []
-        name_index = 0
-        for param in operation.parameters:
+        param_names = param_names or [None] * len(operation.parameters)
+        if len(param_names) != len(operation.parameters):
+            raise ValueError("Parameter names list must be equal to number of operation parameters")
+        for param_name, param in zip(param_names, operation.parameters):
             # PennyLane passes any non-keyword argument in the operation.parameters list.
             # In some cases, like the unitary gate or qml.QubitChannel (Kraus noise), these
             # parameter can be matrices. Braket only supports parameterization of numeric parameters
             # (so far, these are all angle parameters), so non-numeric parameters are handled
             # separately.
-            if isinstance(param, numbers.Number):
-                new_param = FreeParameter(param_names[name_index])
-                name_index += 1
+            if param_name is not None:
+                new_param = FreeParameter(param_name)
             elif isinstance(param, qml.numpy.tensor):
                 new_param = param.numpy()
             else:

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -217,8 +217,6 @@ def test_apply_unique_parameters():
         gamma=FreeParameter("p_4"),
         probability=FreeParameter("p_5"),
     )
-    print(circuit)
-    print(expected)
     assert circuit == expected
 
 

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -329,6 +329,14 @@ def test_translate_operation_iswap_inverse():
     assert translate_operation(qml.ISWAP(wires=[0, 1]).inv()) == gates.PSwap(3 * np.pi / 2)
 
 
+def test_translate_operation_param_names_wrong_length():
+    """Tests that translation fails if provided param_names list is the wrong length"""
+    with pytest.raises(
+        ValueError, match="Parameter names list must be equal to number of operation parameters"
+    ):
+        translate_operation(qml.RX(0.432, wires=0), use_unique_params=True, param_names=["a", "b"])
+
+
 @pytest.mark.parametrize(
     "return_type, braket_result_type", zip(pl_return_types, braket_result_types)
 )


### PR DESCRIPTION
Sends fewer input parameters to the service, and also improves translation speed my only iterating over operation list once.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.