### PR TITLE
Make plugin compatible with new return types specification

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -40,7 +40,6 @@ from enum import Enum, auto
 from typing import Dict, FrozenSet, Iterable, List, Optional, Sequence, Union
 
 import numpy as onp
-
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch, AwsSession
 from braket.circuits import Circuit, Instruction
 from braket.circuits.noise_model import NoiseModel
@@ -249,7 +248,7 @@ class BraketQubitDevice(QubitDevice):
             # adjoint gradient results are a "ragged nested sequences (which is a list-or-tuple of
             # lists-or-tuples-or ndarrays with different lengths or shapes)", so we have to set
             # dtype="object", otherwise numpy will throw a warning
- 
+
             # whenever the adjoint gradient result type is present, it should be the only result
             # type, which is why this changing of dtype works. If we ever change this plugin
             # to submit another result type alongside adjoint gradient, this logic will need to

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -39,6 +39,8 @@ import numbers
 from enum import Enum, auto
 from typing import Dict, FrozenSet, Iterable, List, Optional, Sequence, Union
 
+import numpy as onp
+
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch, AwsSession
 from braket.circuits import Circuit, Instruction
 from braket.circuits.noise_model import NoiseModel
@@ -231,7 +233,12 @@ class BraketQubitDevice(QubitDevice):
         # Compute the required statistics
         results = self.statistics(braket_result, circuit.observables)
         if active_return():
-            return tuple(results)
+            # Assuming that the braket device doesn't have native parameter broadcasting
+            # Assuming that the braket device doesn't support shot vectors.
+            # Otherwise, we may need additional nesting
+            if len(circuit.measurements) == 1:
+                return onp.array(results).squeeze()
+            return tuple(onp.array(res).squeeze() for res in results)
         ag_results = [
             result
             for result in braket_result.result_types
@@ -242,7 +249,7 @@ class BraketQubitDevice(QubitDevice):
             # adjoint gradient results are a "ragged nested sequences (which is a list-or-tuple of
             # lists-or-tuples-or ndarrays with different lengths or shapes)", so we have to set
             # dtype="object", otherwise numpy will throw a warning
-
+ 
             # whenever the adjoint gradient result type is present, it should be the only result
             # type, which is why this changing of dtype works. If we ever change this plugin
             # to submit another result type alongside adjoint gradient, this logic will need to


### PR DESCRIPTION
*Description of changes:*

With version `v0.30` of PennyLane, the new return types specification in enabled by default. Instead of forcing results into a ragged numpy array, devices, QNodes, and everything in between use tuples of information instead.

For example:
```
@qml.qnode(qml.device('braket.local.qubit', wires=n_wires), diff_method=None)
def circuit():
    return qml.expval(qml.PauliZ(0)), qml.probs()

circuit()
```
```
(array(1.), array([1., 0., 0., 0.]))
```

*Testing done:*

Local unit tests pass.  The `pl-device-test` also passes with the local simulator.

Integration tests with remote simulator or hardware have not yet been run due to difficulties configuring the aws profile.

I can add more local tests for multiple measurements, as most tests cases on the plugin currently only test for a single measurement.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.