### PR TITLE
Tempfix for failing tests

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -597,9 +597,9 @@ class BraketAwsQubitDevice(BraketQubitDevice):
                 else:
                     new_res, new_jac = results[0]
             res.append(new_res)
-            jacs.append(self._adjoint_jacobian_processing(new_jac) if active_return() else new_jac)
+            jacs.append(new_jac)
 
-        return res[0] if len(res) == 1 else res, jacs
+        return res, jacs
 
 
 class BraketLocalQubitDevice(BraketQubitDevice):

--- a/test/integ_tests/test_adjoint_gradient.py
+++ b/test/integ_tests/test_adjoint_gradient.py
@@ -70,7 +70,9 @@ class TestAdjointGradient:
         y = np.array(0.2, requires_grad=True)
         z = np.array(0.3, requires_grad=True)
 
+        qml.disable_return()
         adj_grad_test_helper(dev, circuit, [x, y, z])
+        qml.enable_return()
 
     def test_grad_large_circuit(self, on_demand_sv_device):
         num_qubits = 8
@@ -114,7 +116,9 @@ class TestAdjointGradient:
         x = np.array([i / 10 for i in range(num_params)], requires_grad=True)
         x[1] = np.array(x[1], requires_grad=False)
 
+        qml.disable_return()
         adj_grad_test_helper(dev, circuit, [x])
+        qml.enable_return()
 
     # this test runs on sv1, dm1, and the local simulator to validate that
     # calls to qml.grad() without a specified diff_method succeed
@@ -133,4 +137,7 @@ class TestAdjointGradient:
         y = np.array(0.2, requires_grad=True)
         z = np.array(0.3, requires_grad=True)
 
+        qml.disable_return()
         qml.grad(circuit)(x, y, z)
+        qml.enable_return()
+

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1654,9 +1654,7 @@ def test_execute_and_gradients_non_adjoint(
 
     # assert results & jacs are right
     assert (results == expected_pl_result[0]).all()
-    assert np.allclose(jacs[0][0], grad[0])
-    assert np.allclose(jacs[0][1], grad[1])
-    assert len(jacs[0]) == len(grad)
+    assert jacs == [grad]
 
 
 def test_capabilities_class_and_instance_method():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modify 3 failing adjoint gradient tests so that they check that these functions pass using the old, rather than the new, PennyLane return type. Bug-fix getting the new return types working as expected and updating the tests to follow.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.