### PR TITLE
feature: implement support for classical shadows and computing expectation values with them

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -334,36 +334,44 @@ class BraketQubitDevice(QubitDevice):
             )
             for snapshot_rotation in snapshot_rotations
         ]
-        task_batch = self._device.run_batch(
-            snapshot_circuits,
-            s3_destination_folder=self._s3_folder,
-            shots=1,
-            max_parallel=self._max_parallel,
-            max_connections=self._max_connections,
-            poll_timeout_seconds=self._poll_timeout_seconds,
-            poll_interval_seconds=self._poll_interval_seconds,
-            **self._run_kwargs,
-        )
 
-        # Call results() to retrieve the Braket results in parallel.
-        try:
-            braket_results_batch = task_batch.results(
-                fail_unsuccessful=True, max_retries=self._max_retries
+        if self._parallel:
+            task_batch = self._device.run_batch(
+                snapshot_circuits,
+                s3_destination_folder=self._s3_folder,
+                shots=1,
+                max_parallel=self._max_parallel,
+                max_connections=self._max_connections,
+                poll_timeout_seconds=self._poll_timeout_seconds,
+                poll_interval_seconds=self._poll_interval_seconds,
+                **self._run_kwargs,
             )
 
-        # Update the tracker before raising an exception further if some circuits do not complete.
-        finally:
-            if self.tracker.active:
-                for task in task_batch.tasks:
-                    tracking_data = self._tracking_data(task)
-                    self.tracker.update(**tracking_data)
-                total_executions = len(task_batch.tasks) - len(task_batch.unsuccessful)
-                total_shots = total_executions
-                self.tracker.update(batches=1, executions=total_executions, shots=total_shots)
-                self.tracker.record()
+            # Call results() to retrieve the Braket results in parallel.
+            try:
+                braket_results_batch = task_batch.results(
+                    fail_unsuccessful=True, max_retries=self._max_retries
+                )
 
-        for t in range(n_snapshots):
-            outcomes[t] = np.array(braket_results_batch[t].measurements[0])[mapped_wires]
+            # Update the tracker before raising an exception further if some circuits do not complete.
+            finally:
+                if self.tracker.active:
+                    for task in task_batch.tasks:
+                        tracking_data = self._tracking_data(task)
+                        self.tracker.update(**tracking_data)
+                    total_executions = len(task_batch.tasks) - len(task_batch.unsuccessful)
+                    total_shots = total_executions
+                    self.tracker.update(batches=1, executions=total_executions, shots=total_shots)
+                    self.tracker.record()
+
+            for t in range(n_snapshots):
+                outcomes[t] = np.array(braket_results_batch[t].measurements[0])[mapped_wires]
+        else:
+            for t in range(n_snapshots):
+                task = self._device.run(snapshot_circuits[t], shots=1, **self._run_kwargs)
+
+                res = task.result()
+                outcomes[t] = np.array(res.measurements[0])[mapped_wires]
 
         return self._cast(self._stack([outcomes, recipes]), dtype=np.int8)
 
@@ -730,46 +738,3 @@ class BraketLocalQubitDevice(BraketQubitDevice):
             inputs=inputs or {},
             **self._run_kwargs,
         )
-
-    def classical_shadow(self, obs, circuit):
-        if circuit is None:  # pragma: no cover
-            raise ValueError("Circuit must be provided when measuring classical shadows")
-
-        wires = obs.wires
-        n_snapshots = self.shots
-        seed = obs.seed
-
-        n_qubits = len(wires)
-        mapped_wires = np.array(self.map_wires(wires))
-        # seed the random measurement generation so that recipes
-        # are the same for different executions with the same seed
-        rng = np.random.default_rng(seed)
-        recipes = rng.integers(0, 3, size=(n_snapshots, n_qubits))
-        obs_list = [qml.PauliX, qml.PauliY, qml.PauliZ]
-
-        outcomes = np.zeros((n_snapshots, n_qubits))
-
-        snapshot_rotations = [
-            [
-                rot
-                for wire_idx, wire in enumerate(wires)
-                for rot in obs_list[recipes[t][wire_idx]].compute_diagonalizing_gates(wires=wire)
-            ]
-            for t in range(n_snapshots)
-        ]
-
-        snapshot_circuits = [
-            self.apply(
-                circuit.operations,
-                rotations=circuit.diagonalizing_gates + snapshot_rotation,
-                use_unique_params=False,
-            )
-            for snapshot_rotation in snapshot_rotations
-        ]
-        for t in range(n_snapshots):
-            task = self._device.run(snapshot_circuits[t], shots=1, **self._run_kwargs)
-
-            res = task.result()
-            outcomes[t] = np.array(res.measurements[0])[mapped_wires]
-
-        return self._cast(self._stack([outcomes, recipes]), dtype=np.int8)

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -173,7 +173,7 @@ class BraketQubitDevice(QubitDevice):
         )
         if compute_gradient:
             braket_circuit = self._apply_gradient_result_type(circuit, braket_circuit)
-        elif not isinstance(circuit.observables[0], ShadowExpvalMP):
+        elif not isinstance(circuit.observables[0], MeasurementTransform):
             for observable in circuit.observables:
                 dev_wires = self.map_wires(observable.wires).tolist()
                 translated = translate_result_type(observable, dev_wires, self._braket_result_types)
@@ -373,6 +373,8 @@ class BraketQubitDevice(QubitDevice):
                     "have that as its only result type."
                 )
             return [self.shadow_expval(circuit.observables[0], circuit)]
+        else:
+            raise RuntimeError("The circuit has an unsupported MeasurementTransform.")
 
     def _execute_legacy(
         self, circuit: QuantumTape, compute_gradient=False, **run_kwargs

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -76,6 +76,7 @@ from ._version import __version__
 
 RETURN_TYPES = [Expectation, Variance, Sample, Probability, State]
 MIN_SIMULATOR_BILLED_MS = 3000
+OBS_LIST = (qml.PauliX, qml.PauliY, qml.PauliZ)
 
 
 class Shots(Enum):
@@ -313,7 +314,6 @@ class BraketQubitDevice(QubitDevice):
         # are the same for different executions with the same seed
         rng = np.random.default_rng(seed)
         recipes = rng.integers(0, 3, size=(n_snapshots, n_qubits))
-        obs_list = [qml.PauliX, qml.PauliY, qml.PauliZ]
 
         outcomes = np.zeros((n_snapshots, n_qubits))
 
@@ -321,7 +321,7 @@ class BraketQubitDevice(QubitDevice):
             [
                 rot
                 for wire_idx, wire in enumerate(wires)
-                for rot in obs_list[recipes[t][wire_idx]].compute_diagonalizing_gates(wires=wire)
+                for rot in OBS_LIST[recipes[t][wire_idx]].compute_diagonalizing_gates(wires=wire)
             ]
             for t in range(n_snapshots)
         ]

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -182,8 +182,6 @@ class BraketQubitDevice(QubitDevice):
                         braket_circuit.add_result_type(result_type)
                 else:
                     braket_circuit.add_result_type(translated)
-        else:
-            return braket_circuit
         return braket_circuit
 
     def _apply_gradient_result_type(self, circuit, braket_circuit):
@@ -373,8 +371,7 @@ class BraketQubitDevice(QubitDevice):
                     "have that as its only result type."
                 )
             return [self.shadow_expval(circuit.observables[0], circuit)]
-        else:
-            raise RuntimeError("The circuit has an unsupported MeasurementTransform.")
+        raise RuntimeError("The circuit has an unsupported MeasurementTransform.")
 
     def _execute_legacy(
         self, circuit: QuantumTape, compute_gradient=False, **run_kwargs

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -172,9 +172,7 @@ class BraketQubitDevice(QubitDevice):
         )
         if compute_gradient:
             braket_circuit = self._apply_gradient_result_type(circuit, braket_circuit)
-        elif isinstance(circuit.observables[0], ShadowExpvalMP):
-            return braket_circuit
-        else:
+        elif not isinstance(circuit.observables[0], ShadowExpvalMP):
             for observable in circuit.observables:
                 dev_wires = self.map_wires(observable.wires).tolist()
                 translated = translate_result_type(observable, dev_wires, self._braket_result_types)
@@ -183,6 +181,8 @@ class BraketQubitDevice(QubitDevice):
                         braket_circuit.add_result_type(result_type)
                 else:
                     braket_circuit.add_result_type(translated)
+        else:
+            return braket_circuit
         return braket_circuit
 
     def _apply_gradient_result_type(self, circuit, braket_circuit):

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -41,6 +41,7 @@ from enum import Enum, auto
 from typing import Dict, FrozenSet, Iterable, List, Optional, Sequence, Union
 
 import numpy as onp
+import pennylane as qml
 from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch, AwsSession
 from braket.circuits import Circuit, Instruction
 from braket.circuits.noise_model import NoiseModel
@@ -53,17 +54,16 @@ from pennylane import numpy as np
 from pennylane.gradients import param_shift
 from pennylane.measurements import (
     Expectation,
+    MeasurementTransform,
     Probability,
     Sample,
+    ShadowExpvalMP,
     State,
     Variance,
-    MeasurementTransform,
-    ShadowExpvalMP,
 )
 from pennylane.operation import Observable, Operation
 from pennylane.ops.qubit.hamiltonian import Hamiltonian
 from pennylane.tape import QuantumTape
-import pennylane as qml
 
 from braket.pennylane_plugin.translation import (
     get_adjoint_gradient_result_type,
@@ -308,7 +308,6 @@ class BraketQubitDevice(QubitDevice):
         wires = obs.wires
         n_snapshots = self.shots
         seed = obs.seed
-
         n_qubits = len(wires)
         mapped_wires = np.array(self.map_wires(wires))
         # seed the random measurement generation so that recipes
@@ -336,43 +335,7 @@ class BraketQubitDevice(QubitDevice):
             for snapshot_rotation in snapshot_rotations
         ]
 
-        if self._parallel:
-            task_batch = self._device.run_batch(
-                snapshot_circuits,
-                s3_destination_folder=self._s3_folder,
-                shots=1,
-                max_parallel=self._max_parallel,
-                max_connections=self._max_connections,
-                poll_timeout_seconds=self._poll_timeout_seconds,
-                poll_interval_seconds=self._poll_interval_seconds,
-                **self._run_kwargs,
-            )
-
-            # Call results() to retrieve the Braket results in parallel.
-            try:
-                braket_results_batch = task_batch.results(
-                    fail_unsuccessful=True, max_retries=self._max_retries
-                )
-
-            # Update the tracker before raising an exception further if some circuits do not complete.
-            finally:
-                if self.tracker.active:
-                    for task in task_batch.tasks:
-                        tracking_data = self._tracking_data(task)
-                        self.tracker.update(**tracking_data)
-                    total_executions = len(task_batch.tasks) - len(task_batch.unsuccessful)
-                    total_shots = total_executions
-                    self.tracker.update(batches=1, executions=total_executions, shots=total_shots)
-                    self.tracker.record()
-
-            for t in range(n_snapshots):
-                outcomes[t] = np.array(braket_results_batch[t].measurements[0])[mapped_wires]
-        else:
-            for t in range(n_snapshots):
-                task = self._device.run(snapshot_circuits[t], shots=1, **self._run_kwargs)
-
-                res = task.result()
-                outcomes[t] = np.array(res.measurements[0])[mapped_wires]
+        outcomes = self._run_snapshots(snapshot_circuits, n_qubits, mapped_wires)
 
         return self._cast(self._stack([outcomes, recipes]), dtype=np.int8)
 
@@ -404,6 +367,11 @@ class BraketQubitDevice(QubitDevice):
                 self.tracker.record()
             return self._braket_to_pl_result(braket_result, circuit)
         elif isinstance(circuit.observables[0], ShadowExpvalMP):
+            if len(circuit.observables) > 1:
+                raise ValueError(
+                    "A circuit with a ShadowExpvalMP observable must "
+                    "have that as its only result type."
+                )
             return [self.shadow_expval(circuit.observables[0], circuit)]
 
     def _execute_legacy(
@@ -477,6 +445,9 @@ class BraketQubitDevice(QubitDevice):
 
     def _run_task(self, circuit, inputs=None):
         raise NotImplementedError("Need to implement task runner")
+
+    def _run_snapshots(self, snapshot_circuits, n_qubits, mapped_wires):
+        raise NotImplementedError("Need to implement snapshots runner")
 
     def _get_statistic(self, braket_result, observable):
         dev_wires = self.map_wires(observable.wires).tolist()
@@ -652,6 +623,56 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             **self._run_kwargs,
         )
 
+    def _run_snapshots(self, snapshot_circuits, n_qubits, mapped_wires):
+        n_snapshots = len(snapshot_circuits)
+        outcomes = np.zeros((n_snapshots, n_qubits))
+        if self._parallel:
+            task_batch = self._device.run_batch(
+                snapshot_circuits,
+                s3_destination_folder=self._s3_folder,
+                shots=1,
+                max_parallel=self._max_parallel,
+                max_connections=self._max_connections,
+                poll_timeout_seconds=self._poll_timeout_seconds,
+                poll_interval_seconds=self._poll_interval_seconds,
+                **self._run_kwargs,
+            )
+
+            # Call results() to retrieve the Braket results in parallel.
+            try:
+                braket_results_batch = task_batch.results(
+                    fail_unsuccessful=True, max_retries=self._max_retries
+                )
+
+            # Update the tracker before raising an exception further
+            # if some circuits do not complete.
+            finally:
+                if self.tracker.active:
+                    for task in task_batch.tasks:
+                        tracking_data = self._tracking_data(task)
+                        self.tracker.update(**tracking_data)
+                    total_executions = len(task_batch.tasks) - len(task_batch.unsuccessful)
+                    total_shots = total_executions
+                    self.tracker.update(batches=1, executions=total_executions, shots=total_shots)
+                    self.tracker.record()
+
+            for t in range(n_snapshots):
+                outcomes[t] = np.array(braket_results_batch[t].measurements[0])[mapped_wires]
+        else:
+            for t in range(n_snapshots):
+                task = self._device.run(
+                    snapshot_circuits[t],
+                    shots=1,
+                    s3_destination_folder=self._s3_folder,
+                    poll_timeout_seconds=self._poll_timeout_seconds,
+                    poll_interval_seconds=self._poll_interval_seconds,
+                    **self._run_kwargs,
+                )
+                res = task.result()
+                outcomes[t] = np.array(res.measurements[0])[mapped_wires]
+
+        return outcomes
+
     def capabilities(self=None):
         """Add support for AG on sv1"""
         # normally, we'd just call super().capabilities() here, but super()
@@ -739,3 +760,12 @@ class BraketLocalQubitDevice(BraketQubitDevice):
             inputs=inputs or {},
             **self._run_kwargs,
         )
+
+    def _run_snapshots(self, snapshot_circuits, n_qubits, mapped_wires):
+        n_snapshots = len(snapshot_circuits)
+        outcomes = np.zeros((n_snapshots, n_qubits))
+        for t in range(n_snapshots):
+            task = self._device.run(snapshot_circuits[t], shots=1, **self._run_kwargs)
+            res = task.result()
+            outcomes[t] = np.array(res.measurements[0])[mapped_wires]
+        return outcomes

--- a/test/integ_tests/test_shadow_expval.py
+++ b/test/integ_tests/test_shadow_expval.py
@@ -8,19 +8,21 @@ np.random.seed(seed)
 H = qml.PauliZ(0) @ qml.PauliZ(1)
 wires = 2
 
+
 @pytest.mark.parametrize("shots", [10000])
 class TestShadowExpval:
     """Test shadow_expval computation of expectation values."""
 
     def test_shadow_expval(self, device, shots):
         dev = device(wires)
+
         @qml.qnode(dev)
         def shadow_circuit(x):
             qml.Hadamard(wires=0)
             qml.CNOT(wires=[0, 1])
             qml.RX(x, wires=0)
             return qml.shadow_expval(H, seed=seed)
-        
+
         @qml.qnode(dev)
         def circuit(x):
             qml.Hadamard(wires=0)
@@ -29,6 +31,6 @@ class TestShadowExpval:
             return qml.expval(H)
 
         x = np.array(1.2)
-        shadow_e = shadow_circuit(x) 
+        shadow_e = shadow_circuit(x)
         e = circuit(x)
-        assert np.allclose([shadow_e], [e], rtol=0.5) 
+        assert np.allclose([shadow_e], [e], rtol=0.5)

--- a/test/integ_tests/test_shadow_expval.py
+++ b/test/integ_tests/test_shadow_expval.py
@@ -6,14 +6,14 @@ import pytest
 seed = 42
 np.random.seed(seed)
 H = qml.PauliZ(0) @ qml.PauliZ(1)
-shots = 10000
 wires = 2
 
+@pytest.mark.parametrize("shots", [10000])
 class TestShadowExpval:
     """Test shadow_expval computation of expectation values."""
 
-    @pytest.mark.parametrize("dev", [qml.device("default.qubit", wires=wires, shots=shots), qml.device("braket.local.qubit", wires=wires, shots=shots)])
-    def test_shadow_expval(self, dev):
+    def test_shadow_expval(self, device, shots):
+        dev = device(wires)
         @qml.qnode(dev)
         def shadow_circuit(x):
             qml.Hadamard(wires=0)

--- a/test/integ_tests/test_shadow_expval.py
+++ b/test/integ_tests/test_shadow_expval.py
@@ -2,7 +2,6 @@ import pennylane as qml
 import pennylane.numpy as np
 import pytest
 
-
 seed = 42
 np.random.seed(seed)
 H = qml.PauliZ(0) @ qml.PauliZ(1)

--- a/test/integ_tests/test_shadow_expval.py
+++ b/test/integ_tests/test_shadow_expval.py
@@ -1,0 +1,34 @@
+import pennylane as qml
+import pennylane.numpy as np
+import pytest
+
+
+seed = 42
+np.random.seed(seed)
+H = qml.PauliZ(0) @ qml.PauliZ(1)
+shots = 10000
+wires = 2
+
+class TestShadowExpval:
+    """Test shadow_expval computation of expectation values."""
+
+    @pytest.mark.parametrize("dev", [qml.device("default.qubit", wires=wires, shots=shots), qml.device("braket.local.qubit", wires=wires, shots=shots)])
+    def test_shadow_expval(self, dev):
+        @qml.qnode(dev)
+        def shadow_circuit(x):
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RX(x, wires=0)
+            return qml.shadow_expval(H, seed=seed)
+        
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RX(x, wires=0)
+            return qml.expval(H)
+
+        x = np.array(1.2)
+        shadow_e = shadow_circuit(x) 
+        e = circuit(x)
+        assert np.allclose([shadow_e], [e], rtol=0.5) 

--- a/test/unit_tests/test_shadow_expval.py
+++ b/test/unit_tests/test_shadow_expval.py
@@ -1,0 +1,338 @@
+import json
+from unittest import mock
+from unittest.mock import Mock, PropertyMock, patch
+
+import pennylane as qml
+import pytest
+from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask
+from braket.circuits import Circuit
+from braket.device_schema import DeviceActionType
+from braket.device_schema.openqasm_device_action_properties import OpenQASMDeviceActionProperties
+from braket.devices import LocalSimulator
+from braket.task_result import GateModelTaskResult
+from braket.tasks import GateModelQuantumTaskResult
+from pennylane.tape import QuantumScript, QuantumTape
+
+from braket.pennylane_plugin import BraketAwsQubitDevice, BraketLocalQubitDevice
+
+SHOTS = 2
+DEVICE_ARN = "baz"
+SEED = 42
+
+ACTION_PROPERTIES = OpenQASMDeviceActionProperties.parse_raw(
+    json.dumps(
+        {
+            "actionType": "braket.ir.openqasm.program",
+            "version": ["1"],
+            "supportedOperations": ["rx", "ry", "h", "cy", "cnot", "unitary"],
+            "supportedResultTypes": [
+                {"name": "StateVector", "observables": None, "minShots": 0, "maxShots": 0},
+                {
+                    "name": "AdjointGradient",
+                    "observables": ["x", "y", "z", "h", "i"],
+                    "minShots": 0,
+                    "maxShots": 0,
+                },
+            ],
+        }
+    )
+)
+
+SNAPSHOTS = [[0, 0], [1, 1]]
+
+GATE_MODEL_RESULT = GateModelTaskResult(
+    **{
+        "measurements": SNAPSHOTS,
+        "measuredQubits": [0, 1],
+        "taskMetadata": {
+            "braketSchemaHeader": {"name": "braket.task_result.task_metadata", "version": "1"},
+            "id": "task_arn",
+            "shots": SHOTS,
+            "deviceId": "default",
+        },
+        "additionalMetadata": {
+            "action": {
+                "braketSchemaHeader": {"name": "braket.ir.openqasm.program", "version": "1"},
+                "source": "qubit[2] q; cnot q[0], q[1]; measure q;",
+            },
+        },
+    }
+)
+
+RESULT = GateModelQuantumTaskResult.from_string(
+    json.dumps(
+        {
+            "braketSchemaHeader": {
+                "name": "braket.task_result.gate_model_task_result",
+                "version": "1",
+            },
+            "measurements": [SNAPSHOTS[0]],
+            "resultTypes": [],
+            "measuredQubits": [0, 1],
+            "taskMetadata": {
+                "braketSchemaHeader": {"name": "braket.task_result.task_metadata", "version": "1"},
+                "id": "task_arn",
+                "shots": 1,
+                "deviceId": "default",
+            },
+            "additionalMetadata": {
+                "action": {
+                    "braketSchemaHeader": {"name": "braket.ir.openqasm.program", "version": "1"},
+                    "source": "qubit[2] q; cnot q[0], q[1]; measure q;",
+                },
+            },
+        }
+    )
+)
+
+BATCH_RESULT_1 = GateModelQuantumTaskResult.from_string(
+    json.dumps(
+        {
+            "braketSchemaHeader": {
+                "name": "braket.task_result.gate_model_task_result",
+                "version": "1",
+            },
+            "measurements": [SNAPSHOTS[0]],
+            "resultTypes": [],
+            "measuredQubits": [0, 1],
+            "taskMetadata": {
+                "braketSchemaHeader": {"name": "braket.task_result.task_metadata", "version": "1"},
+                "id": "task_arn",
+                "shots": 1,
+                "deviceId": "default",
+            },
+            "additionalMetadata": {
+                "action": {
+                    "braketSchemaHeader": {"name": "braket.ir.openqasm.program", "version": "1"},
+                    "source": "qubit[2] q; cnot q[0], q[1]; measure q;",
+                },
+            },
+        }
+    )
+)
+BATCH_RESULT_2 = GateModelQuantumTaskResult.from_string(
+    json.dumps(
+        {
+            "braketSchemaHeader": {
+                "name": "braket.task_result.gate_model_task_result",
+                "version": "1",
+            },
+            "measurements": [SNAPSHOTS[1]],
+            "resultTypes": [],
+            "measuredQubits": [0, 1],
+            "taskMetadata": {
+                "braketSchemaHeader": {"name": "braket.task_result.task_metadata", "version": "1"},
+                "id": "task_arn",
+                "shots": 1,
+                "deviceId": "default",
+            },
+            "additionalMetadata": {
+                "action": {
+                    "braketSchemaHeader": {"name": "braket.ir.openqasm.program", "version": "1"},
+                    "source": "qubit[2] q; cnot q[0], q[1]; measure q;",
+                },
+            },
+        }
+    )
+)
+TASK = Mock()
+TASK.result.return_value = RESULT
+type(TASK).id = PropertyMock(return_value="task_arn")
+TASK.state.return_value = "COMPLETED"
+TASK_BATCH = Mock()
+TASK_BATCH.results.return_value = [BATCH_RESULT_1, BATCH_RESULT_2]
+type(TASK_BATCH).tasks = PropertyMock(return_value=[TASK, TASK])
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_only_one_operator_in_shadow_expval():
+    """Tests that the correct circuit is created when not all wires in the device are used."""
+    dev = _aws_device(wires=2)
+    with QuantumTape() as circuit:
+        qml.Hadamard(wires=0)
+        qml.RX(0.432, wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.shadow_expval(qml.PauliX(1))
+        qml.probs(wires=[0, 1])
+
+    dev.execute(circuit)
+
+
+CIRCUIT_1 = QuantumScript(
+    ops=[
+        qml.Hadamard(wires=0),
+        qml.CNOT(wires=[0, 1]),
+        qml.RX(0.432, wires=0),
+        qml.RY(0.543, wires=0),
+    ],
+    measurements=[qml.shadow_expval(qml.PauliX(1), seed=SEED)],
+)
+CIRCUIT_1.trainable_params = [0]
+
+circs = [Circuit().h(0).cnot(0, 1).rx(0, 0.432).ry(0, 0.543) for s in range(SHOTS)]
+# basis rotation with seed
+circs[0].h(1)
+
+
+@patch.object(AwsDevice, "run")
+@patch.object(AwsDevice, "run_batch")
+@pytest.mark.parametrize(
+    "pl_circ, wires, result_types, expected_pl_result",
+    [
+        (
+            CIRCUIT_1,
+            2,
+            [
+                {
+                    "type": {
+                        "observable": "x()",
+                        "targets": [[0]],
+                        "parameters": ["p_0", "p_1"],
+                        "type": "expectation_value",
+                    },
+                    "value": {
+                        "expectation": 1.5,
+                    },
+                },
+            ],
+            [[1.5]],
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parallel, expected_braket_circ, return_val, call_count, max_para, max_conn",
+    [
+        (False, circs, TASK, SHOTS, None, None),
+        (True, circs, TASK_BATCH, 1, 10, 10),
+    ],
+)
+def test_shadow_expval_aws_device(
+    mock_run_batch,
+    mock_run,
+    pl_circ,
+    wires,
+    result_types,
+    expected_pl_result,
+    parallel,
+    expected_braket_circ,
+    return_val,
+    call_count,
+    max_para,
+    max_conn,
+):
+    dev = _aws_device(
+        wires=2, foo="bar", parallel=parallel, max_parallel=max_para, max_connections=max_conn
+    )
+    mock_runner = mock_run_batch if parallel else mock_run
+    mock_runner.return_value = return_val
+    res = dev.execute(pl_circ)
+    kwargs = {"max_parallel": max_para, "max_connections": max_conn} if parallel else {}
+    assert mock_runner.call_count == call_count
+    # assert results are right
+    assert res == expected_pl_result[0]
+    if parallel:
+        mock_runner.assert_called_with(
+            expected_braket_circ,
+            s3_destination_folder=("foo", "bar"),
+            shots=1,
+            **kwargs,
+            poll_timeout_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+            poll_interval_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
+            foo="bar",
+        )
+    else:
+        for c in expected_braket_circ:
+            mock_runner.assert_any_call(
+                c,
+                s3_destination_folder=("foo", "bar"),
+                shots=1,
+                **kwargs,
+                poll_timeout_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+                poll_interval_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
+                foo="bar",
+            )
+
+
+@patch.object(LocalSimulator, "run")
+@pytest.mark.parametrize(
+    "pl_circ, expected_braket_circ, wires, result_types, expected_pl_result",
+    [
+        (
+            CIRCUIT_1,
+            Circuit().h(0).cnot(0, 1).rx(0, 0.432).ry(0, 0.543),
+            2,
+            [
+                {
+                    "type": {
+                        "observable": "x()",
+                        "targets": [[0]],
+                        "parameters": ["p_0", "p_1"],
+                        "type": "expectation_value",
+                    },
+                    "value": {
+                        "expectation": 1.5,
+                    },
+                },
+            ],
+            [[1.5]],
+        ),
+    ],
+)
+@pytest.mark.parametrize("backend", ["default", "braket_sv", "braket_dm"])
+def test_shadow_expval_local(
+    mock_run,
+    pl_circ,
+    expected_braket_circ,
+    wires,
+    result_types,
+    expected_pl_result,
+    backend,
+):
+    dev = BraketLocalQubitDevice(wires=2, backend=backend, shots=SHOTS, foo="bar")
+    mock_run.return_value = TASK
+    res = dev.execute(pl_circ)
+    assert mock_run.call_count == SHOTS
+    # assert results are right
+    assert res == expected_pl_result[0]
+    mock_run.assert_called_with(
+        expected_braket_circ,
+        shots=1,
+        foo="bar",
+    )
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+@patch.object(AwsDevice, "__init__", _noop)
+@patch.object(AwsDevice, "aws_session", new_callable=mock.PropertyMock)
+@patch.object(AwsDevice, "type", new_callable=mock.PropertyMock)
+@patch.object(AwsDevice, "properties")
+def _aws_device(
+    properties_mock,
+    type_mock,
+    session_mock,
+    wires,
+    device_type=AwsDeviceType.QPU,
+    shots=SHOTS,
+    device_arn="baz",
+    action_properties=ACTION_PROPERTIES,
+    **kwargs,
+):
+    properties_mock.action = {DeviceActionType.OPENQASM: action_properties}
+    properties_mock.return_value.action.return_value = {
+        DeviceActionType.OPENQASM: action_properties
+    }
+    type_mock.return_value = device_type
+    dev = BraketAwsQubitDevice(
+        wires=wires,
+        s3_destination_folder=("foo", "bar"),
+        device_arn=device_arn,
+        aws_session=Mock(),
+        shots=shots,
+        **kwargs,
+    )
+    # needed by the BraketAwsQubitDevice.capabilities function
+    dev._device._arn = device_arn
+    return dev


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add support for Braket devices (local and remote) to compute [expectation values](https://pennylane.ai/qml/demos/tutorial_diffable_shadows.html) with the [classical shadows](https://pennylane.ai/qml/demos/tutorial_classical_shadows.html) technique. 

The implementation is a little weird because we have to work around how the current PL device API "expects" plugins to interact with the `ShadowExpvalMP` transform. Each snapshot is a single-shot run so for remote devices, we can use batching to speed up the computation.

*Testing done:*
Basic integration tests added. Very open to suggestions.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.