### PR TITLE
fix: Lower shot count on shadow_expval integ test so it can finish

### DIFF
--- a/test/integ_tests/test_shadow_expval.py
+++ b/test/integ_tests/test_shadow_expval.py
@@ -8,11 +8,10 @@ H = qml.PauliZ(0) @ qml.PauliZ(1)
 wires = 2
 
 
-@pytest.mark.parametrize("shots", [10000])
+@pytest.mark.parametrize("shots", [1000])
 class TestShadowExpval:
     """Test shadow_expval computation of expectation values."""
 
-    @pytest.mark.skip(reason="timing out")
     def test_shadow_expval(self, device, shots):
         dev = device(wires)
 
@@ -33,4 +32,4 @@ class TestShadowExpval:
         x = np.array(1.2)
         shadow_e = shadow_circuit(x)
         e = circuit(x)
-        assert np.allclose([shadow_e], [e], rtol=0.5)
+        assert np.allclose([shadow_e], [e], atol=0.2)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Lowered the shot count to 1000 and loosened tolerances.

*Testing done:* Integ test passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.