### PR TITLE
fix: support noise model in batch_execute

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -183,8 +183,6 @@ class BraketQubitDevice(QubitDevice):
                 else:
                     braket_circuit.add_result_type(translated)
 
-        if self._noise_model:
-            braket_circuit = self._noise_model.apply(braket_circuit)
         return braket_circuit
 
     def _apply_gradient_result_type(self, circuit, braket_circuit):
@@ -417,6 +415,9 @@ class BraketQubitDevice(QubitDevice):
         # To ensure the results have the right number of qubits
         for qubit in sorted(unused):
             circuit.i(qubit)
+
+        if self._noise_model:
+            circuit = self._noise_model.apply(circuit)
 
         return circuit
 

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -182,6 +182,9 @@ class BraketQubitDevice(QubitDevice):
                         braket_circuit.add_result_type(result_type)
                 else:
                     braket_circuit.add_result_type(translated)
+
+        if self._noise_model:
+            braket_circuit = self._noise_model.apply(braket_circuit)
         return braket_circuit
 
     def _apply_gradient_result_type(self, circuit, braket_circuit):
@@ -351,8 +354,6 @@ class BraketQubitDevice(QubitDevice):
             trainable_indices=frozenset(trainable.keys()),
             **run_kwargs,
         )
-        if self._noise_model:
-            self._circuit = self._noise_model.apply(self._circuit)
         if not isinstance(circuit.observables[0], MeasurementTransform):
             self._task = self._run_task(
                 self._circuit, inputs={f"p_{k}": v for k, v in trainable.items()}

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1907,19 +1907,9 @@ def test_invalide_aws_device_for_noise_model(name_mock, device_name, noise_model
         _aws_device(wires=2, device_type=AwsDeviceType.SIMULATOR, noise_model=noise_model)
 
 
-@patch.object(AwsDevice, "run")
-@patch.object(AwsDevice, "name", new_callable=mock.PropertyMock)
-def test_execute_with_noise_model(mock_name, mock_run, noise_model):
-    mock_run.return_value = TASK
-    mock_name.return_value = "dm1"
-    dev = _aws_device(
-        wires=4,
-        device_type=AwsDeviceType.SIMULATOR,
-        noise_model=noise_model,
-        action_properties=ACTION_PROPERTIES_DM_DEVICE,
-    )
-
-    with QuantumTape() as circuit:
+@pytest.fixture
+def pennylane_quantum_tape():
+    with QuantumTape() as tape:
         qml.Hadamard(wires=0)
         qml.QubitUnitary(1 / np.sqrt(2) * np.array([[1, 1], [1, -1]]), wires=0)
         qml.RX(0.432, wires=0)
@@ -1928,13 +1918,12 @@ def test_execute_with_noise_model(mock_name, mock_run, noise_model):
         qml.expval(qml.PauliX(1))
         qml.var(qml.PauliY(2))
         qml.sample(qml.PauliZ(3))
-    circuit.trainable_params = []
+    return tape
 
-    _ = dev.execute(circuit)
 
-    assert dev.task == TASK
-
-    EXPECTED_CIRC = (
+@pytest.fixture
+def expected_braket_circuit_with_noise():
+    return (
         Circuit()
         .h(0)
         .bit_flip(0, 0.05)
@@ -1949,11 +1938,64 @@ def test_execute_with_noise_model(mock_name, mock_run, noise_model):
         .variance(observable=Observable.Y(), target=2)
         .sample(observable=Observable.Z(), target=3)
     )
+
+
+@patch.object(AwsDevice, "run")
+@patch.object(AwsDevice, "name", new_callable=mock.PropertyMock)
+def test_execute_with_noise_model(
+    mock_name, mock_run, noise_model, pennylane_quantum_tape, expected_braket_circuit_with_noise
+):
+    mock_run.return_value = TASK
+    mock_name.return_value = "dm1"
+    dev = _aws_device(
+        wires=4,
+        device_type=AwsDeviceType.SIMULATOR,
+        noise_model=noise_model,
+        action_properties=ACTION_PROPERTIES_DM_DEVICE,
+    )
+    _ = dev.execute(pennylane_quantum_tape)
+
+    assert dev.task == TASK
+
     mock_run.assert_called_with(
-        EXPECTED_CIRC,
+        expected_braket_circuit_with_noise,
         s3_destination_folder=("foo", "bar"),
         shots=SHOTS,
         poll_timeout_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
         poll_interval_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
         inputs={},
+    )
+
+
+@patch.object(AwsDevice, "run_batch")
+@patch.object(AwsDevice, "name", new_callable=mock.PropertyMock)
+@patch.object(BraketAwsQubitDevice, "_braket_to_pl_result")
+def test_batch_execute_with_noise_model(
+    mock_to_result,
+    mock_name,
+    mock_run_batch,
+    noise_model,
+    pennylane_quantum_tape,
+    expected_braket_circuit_with_noise,
+):
+    NUM_CIRCUITS = 5
+    mock_name.return_value = "dm1"
+    dev = _aws_device(
+        wires=4,
+        device_type=AwsDeviceType.SIMULATOR,
+        noise_model=noise_model,
+        action_properties=ACTION_PROPERTIES_DM_DEVICE,
+        parallel=True,
+    )
+
+    _ = dev.batch_execute([pennylane_quantum_tape] * NUM_CIRCUITS)
+
+    mock_run_batch.assert_called_with(
+        [expected_braket_circuit_with_noise] * NUM_CIRCUITS,
+        s3_destination_folder=("foo", "bar"),
+        shots=SHOTS,
+        poll_timeout_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+        poll_interval_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
+        max_connections=100,
+        max_parallel=None,
     )


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-braket-pennylane-plugin-python/issues/176

*Description of changes:*
Move code of applying noise_model to circuit translation. Both `execute` and `batch_execute` call circuit translation before running, assuring the noise model is applied to circuits.

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.