### PR TITLE
Fix compatibility with the new Projector class

### DIFF
--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -531,11 +531,14 @@ _one = np.array([[0, 0], [0, 1]])
 
 @_translate_observable.register
 def _(p: qml.Projector):
-    bitstring = p.parameters[0]
+    state, wires = p.parameters[0], p.wires
+    if len(state) == len(wires):  # Basis state
+        products = [_one if b else _zero for b in state]
+        hermitians = [observables.Hermitian(p) for p in products]
+        return observables.TensorProduct(hermitians)
 
-    products = [_one if b else _zero for b in bitstring]
-    hermitians = [observables.Hermitian(p) for p in products]
-    return observables.TensorProduct(hermitians)
+    # State vector
+    return observables.Hermitian(p.matrix())
 
 
 @_translate_observable.register

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -532,12 +532,12 @@ _one = np.array([[0, 0], [0, 1]])
 @_translate_observable.register
 def _(p: qml.Projector):
     state, wires = p.parameters[0], p.wires
-    if len(state) == len(wires):  # Basis state
+    if len(state) == len(wires):  # state is a basis state
         products = [_one if b else _zero for b in state]
         hermitians = [observables.Hermitian(p) for p in products]
         return observables.TensorProduct(hermitians)
 
-    # State vector
+    # state is a state vector
     return observables.Hermitian(p.matrix())
 
 

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -525,6 +525,7 @@ class TestBraketAhsDevice:
             (qml.PauliX(0), True),
             (qml.PauliZ(0), False),
             (qml.Projector([0], wires=[0]), False),
+            (qml.Projector(np.array([1., 1.]) / np.sqrt(2), wires=[0]), True)
             (qml.sum(qml.PauliZ(0), qml.PauliZ(0)), False),  # sum
             (qml.sum(qml.PauliZ(0), qml.PauliY(0)), True),
             (qml.s_prod(3, qml.PauliY(0)), True),  # scalar prod

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -525,7 +525,7 @@ class TestBraketAhsDevice:
             (qml.PauliX(0), True),
             (qml.PauliZ(0), False),
             (qml.Projector([0], wires=[0]), False),
-            (qml.Projector(np.array([1., 1.]) / np.sqrt(2), wires=[0]), True)
+            (qml.Projector(np.array([1.0, 1.0]) / np.sqrt(2), wires=[0]), True),
             (qml.sum(qml.PauliZ(0), qml.PauliZ(0)), False),  # sum
             (qml.sum(qml.PauliZ(0), qml.PauliY(0)), True),
             (qml.s_prod(3, qml.PauliY(0)), True),  # scalar prod

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1413,8 +1413,8 @@ def test_projection():
         assert np.allclose(expval, exp)
 
         var = qnode(thetas, qml.var, proj)
-        assert np.allclose(var, exp - exp ** 2)
-        
+        assert np.allclose(var, exp - exp**2)
+
         samples = qnode(thetas, qml.sample, proj, shots=100).tolist()
         assert set(samples) == {0, 1}
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1395,38 +1395,28 @@ def test_projection():
     def f(thetas, **kwargs):
         [qml.RY(thetas[i], wires=i) for i in range(wires)]
 
-    projector_01 = qml.Projector([0, 1], wires=range(wires))
-    projector_10 = qml.Projector([1, 0], wires=range(wires))
+    projector_01_bs = qml.Projector([0, 1], wires=range(wires))
+    projector_01_sv = qml.Projector([0, 1, 0, 0], wires=range(wires))
+    projector_10_bs = qml.Projector([1, 0], wires=range(wires))
+    projector_10_sv = qml.Projector([0, 0, 1, 0], wires=range(wires))
 
-    # 01 case
+    projectors = [projector_01_bs, projector_01_sv, projector_10_bs, projector_10_sv]
+    expected = [p_01, p_01, p_10, p_10]
+
     @qml.qnode(dev)
-    def f_01(thetas, measure_type):
+    def qnode(thetas, measure_type, observable):
         f(thetas)
-        return measure_type(projector_01)
+        return measure_type(observable)
 
-    expval_01 = f_01(thetas, qml.expval)
-    assert np.allclose(expval_01, p_01)
+    for proj, exp in zip(projectors, expected):
+        expval = qnode(thetas, qml.expval, proj)
+        assert np.allclose(expval, exp)
 
-    var_01 = f_01(thetas, qml.var)
-    assert np.allclose(var_01, p_01 - p_01**2)
-
-    samples = f_01(thetas, qml.sample, shots=100).tolist()
-    assert set(samples) == {0, 1}
-
-    # 10 case
-    @qml.qnode(dev)
-    def f_10(thetas, measure_type):
-        f(thetas)
-        return measure_type(projector_10)
-
-    exp_10 = f_10(thetas, qml.expval)
-    assert np.allclose(exp_10, p_10)
-
-    var_10 = f_10(thetas, qml.var)
-    assert np.allclose(var_10, p_10 - p_10**2)
-
-    samples = f_10(thetas, qml.sample, shots=100).tolist()
-    assert set(samples) == {0, 1}
+        var = qnode(thetas, qml.var, proj)
+        assert np.allclose(var, exp - exp ** 2)
+        
+        samples = qnode(thetas, qml.sample, proj, shots=100).tolist()
+        assert set(samples) == {0, 1}
 
 
 @pytest.mark.xfail(raises=AttributeError)


### PR DESCRIPTION
The plugin is currently not working with the new version of `qml.Projector` that was released with PennyLane 0.31, as we saw with the [last version updates](https://github.com/PennyLaneAI/plugin-test-matrix/pull/43).

I put up a fix for it :)